### PR TITLE
Fix token reuse across API calls

### DIFF
--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -33,7 +33,7 @@ let ENDPOINTS = {
   ROLES_DETAIL: "/api/roles/detail",
   //CLASSROOM
   CLASSROOM: "/api/phonghoc",
-  CLASSROOM_DETAIL:"/api/phonghoc/detail",
+  CLASSROOM_DETAIL: "/api/phonghoc/detail",
 
   S3: "/api/presigned_url",
 };
@@ -41,8 +41,8 @@ import { useUserStore } from "~~/stores/userStore";
 class Request {
   constructor() {
     this.handler = {
-      onRequest({ request, options }) { },
-      onRequestError({ request, options, error }) { },
+      onRequest({ request, options }) {},
+      onRequestError({ request, options, error }) {},
       onResponse({ request, response, options }) {
         return response._data;
       },
@@ -57,19 +57,22 @@ class Request {
         return response._data;
       },
     };
-    const userStore = useUserStore();
-    this.TOKEN = `Bearer ${userStore.token}`;
     this.base_url = useRuntimeConfig().public.baseURL;
+  }
+
+  createHeaders() {
+    const userStore = useUserStore();
+    return {
+      "Content-type": "application/json; charset=UTF-8",
+      Authorization: `Bearer ${userStore.token}`,
+    };
   }
 
   get(url, options) {
     return useFetch(url, {
       baseURL: this.base_url,
       method: "GET",
-      headers: {
-        "Content-type": "application/json; charset=UTF-8",
-        Authorization: this.TOKEN,
-      },
+      headers: this.createHeaders(),
       ...options,
       ...this.handler,
     });
@@ -78,10 +81,7 @@ class Request {
     return useFetch(url, {
       baseURL: this.base_url,
       method: "POST",
-      headers: {
-        "Content-type": "application/json; charset=UTF-8",
-        Authorization: this.TOKEN,
-      },
+      headers: this.createHeaders(),
       ...options,
       ...this.handler,
     });
@@ -90,10 +90,7 @@ class Request {
     return useFetch(url, {
       baseURL: this.base_url,
       method: "PATCH",
-      headers: {
-        "Content-type": "application/json; charset=UTF-8",
-        Authorization: this.TOKEN,
-      },
+      headers: this.createHeaders(),
       ...options,
       ...this.handler,
     });
@@ -102,10 +99,7 @@ class Request {
     return useFetch(url, {
       baseURL: this.base_url,
       method: "PUT",
-      headers: {
-        "Content-type": "application/json; charset=UTF-8",
-        Authorization: this.TOKEN,
-      },
+      headers: this.createHeaders(),
       ...options,
       ...this.handler,
     });
@@ -114,10 +108,7 @@ class Request {
     return useFetch(url, {
       baseURL: this.base_url,
       method: "DELETE",
-      headers: {
-        "Content-type": "application/json; charset=UTF-8",
-        Authorization: this.TOKEN,
-      },
+      headers: this.createHeaders(),
       ...options,
       ...this.handler,
     });


### PR DESCRIPTION
## Summary
- ensure API requests grab the latest token from the store rather than using a stale value

## Testing
- `yarn build` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_684fccb98fa083318f1ba4adef6e6d4a