### PR TITLE
Add permission display on breadcrumb

### DIFF
--- a/components/Base/Breadcrumb.vue
+++ b/components/Base/Breadcrumb.vue
@@ -35,7 +35,7 @@ const PERMISSION_STATE = {
   EDIT: 2,
 };
 
-// Quyền của route hiện tại
+// Quyền của route hiện tại, lưu cả vào store
 const currentPermission = ref(PERMISSION_STATE.NO_ACCESS);
 const permissionLabel = computed(() => {
   switch (currentPermission.value) {
@@ -89,12 +89,14 @@ const updateBreadcrumb = () => {
   // Tính quyền hiện tại dựa trên menu matched
   if (matchedItems.length) {
     const currentItem = matchedItems[matchedItems.length - 1];
-    const parentKey = matchedItems.length > 1 ? matchedItems[matchedItems.length - 2].key : 'menu';
+    const parentKey =
+      matchedItems.length > 1 ? matchedItems[matchedItems.length - 2].key : 'menu';
     const parentPerm = permissionMap.value[parentKey] ?? 0;
     currentPermission.value = (parentPerm >> currentItem.permissionBit) & 0b11;
   } else {
     currentPermission.value = PERMISSION_STATE.NO_ACCESS;
   }
+  settingStore.setCurrentPermission(currentPermission.value);
 
   // Thêm trang chủ nếu không phải là trang chủ
   if (breadcrumbItems.value.length === 0 || breadcrumbItems.value[0].path !== "/") {

--- a/components/Base/Breadcrumb.vue
+++ b/components/Base/Breadcrumb.vue
@@ -11,7 +11,7 @@
           <span>{{ item.title }}</span>
         </span>
       </a-breadcrumb-item>
-      <span class="ml-4 text-xs text-gray-500">Quyền: {{ permissionLabel }}</span>
+      
     </a-breadcrumb>
   </div>
 </template>

--- a/components/Base/Breadcrumb.vue
+++ b/components/Base/Breadcrumb.vue
@@ -11,6 +11,7 @@
           <span>{{ item.title }}</span>
         </span>
       </a-breadcrumb-item>
+      <span class="ml-4 text-xs text-gray-500">Quyền: {{ permissionLabel }}</span>
     </a-breadcrumb>
   </div>
 </template>
@@ -21,6 +22,31 @@ const settingStore = useSettingStore();
 import { useMenu } from "~/composables/useMenu";
 const { visibleMenu } = useMenu();
 const breadcrumbItems = ref([]);
+
+// Map các permission từ store thành dạng { key: permissionValue }
+const permissionMap = computed(() =>
+  Object.fromEntries(settingStore.permissions.map(p => [p.key, p.permissionValue]))
+);
+
+// Các trạng thái quyền
+const PERMISSION_STATE = {
+  NO_ACCESS: 0,
+  VIEW: 1,
+  EDIT: 2,
+};
+
+// Quyền của route hiện tại
+const currentPermission = ref(PERMISSION_STATE.NO_ACCESS);
+const permissionLabel = computed(() => {
+  switch (currentPermission.value) {
+    case PERMISSION_STATE.EDIT:
+      return "Sửa/Xóa";
+    case PERMISSION_STATE.VIEW:
+      return "Chỉ xem";
+    default:
+      return "Không xem";
+  }
+});
 
 // Lấy menu data từ store
 const menuData = computed(() => visibleMenu.value);
@@ -60,6 +86,16 @@ const updateBreadcrumb = () => {
     path: item.url,
   }));
 
+  // Tính quyền hiện tại dựa trên menu matched
+  if (matchedItems.length) {
+    const currentItem = matchedItems[matchedItems.length - 1];
+    const parentKey = matchedItems.length > 1 ? matchedItems[matchedItems.length - 2].key : 'menu';
+    const parentPerm = permissionMap.value[parentKey] ?? 0;
+    currentPermission.value = (parentPerm >> currentItem.permissionBit) & 0b11;
+  } else {
+    currentPermission.value = PERMISSION_STATE.NO_ACCESS;
+  }
+
   // Thêm trang chủ nếu không phải là trang chủ
   if (breadcrumbItems.value.length === 0 || breadcrumbItems.value[0].path !== "/") {
     breadcrumbItems.value.unshift({
@@ -87,6 +123,7 @@ watch(() => route.path, updateBreadcrumb, { immediate: true });
 // Theo dõi thay đổi menu data (nếu cần)
 watch(() => settingStore.menu, updateBreadcrumb);
 watch(() => visibleMenu.value, updateBreadcrumb);
+watch(() => settingStore.permissions, updateBreadcrumb);
 </script>
 
 <style>

--- a/stores/settingStore.js
+++ b/stores/settingStore.js
@@ -12,6 +12,7 @@ export const useSettingStore = defineStore(
       },
       menu: [],
       permissions: [],
+      currentPermission: 0,
     }),
     actions: {
       setLoading(value) {
@@ -26,11 +27,15 @@ export const useSettingStore = defineStore(
       setPermissions(value) {
         this.permissions = value;
       },
+      setCurrentPermission(value) {
+        this.currentPermission = value;
+      },
     },
     getters: {
       menuItems: state => state.menu,
       menuPermissions: state => state.permissions,
       isLoading: state => state.loading.isActive,
+      currentPermission: state => state.currentPermission,
     },
     // persist: {
     //   // storage: piniaPluginPersistedstate.localStorage(),

--- a/stores/settingStore.js
+++ b/stores/settingStore.js
@@ -12,7 +12,7 @@ export const useSettingStore = defineStore(
       },
       menu: [],
       permissions: [],
-      currentPermission: 0,
+      current_permission: 0,
     }),
     actions: {
       setLoading(value) {
@@ -28,14 +28,14 @@ export const useSettingStore = defineStore(
         this.permissions = value;
       },
       setCurrentPermission(value) {
-        this.currentPermission = value;
+        this.current_permission = value;
       },
     },
     getters: {
       menuItems: state => state.menu,
       menuPermissions: state => state.permissions,
       isLoading: state => state.loading.isActive,
-      currentPermission: state => state.currentPermission,
+      currentPermission: state => state.current_permission,
     },
     // persist: {
     //   // storage: piniaPluginPersistedstate.localStorage(),


### PR DESCRIPTION
## Summary
- show permission state in breadcrumb
- compute permission using bit masks for current route

## Testing
- `yarn lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684fdeb9775883319760988010c637cf