### PR TITLE
Add permission check on CRUD buttons

### DIFF
--- a/pages/administration/menu.vue
+++ b/pages/administration/menu.vue
@@ -2,7 +2,7 @@
   <div class="p-4 bg-white rounded shadow min-h-full">
     <!-- 🧭 Thanh công cụ tìm kiếm & thêm mới -->
     <div class="flex flex-col md:flex-row justify-end items-end md:items-center gap-2 mb-6">
-      <a-button type="primary" @click="showModal(null)" class="w-full md:w-auto">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal(null)" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
     <!-- 📋 Bảng danh sách menu -->
@@ -26,18 +26,18 @@
         <template v-if="column.key === 'action'">
           <div class="flex justify-center gap-2">
             <a-tooltip title="Thêm menu con" v-if="getDepth(record) < 2">
-              <a-button type="link" size="small" @click="showModal(record.id)">
+              <a-button type="link" size="small" @click="showModal(record.id)" :disabled="!settingStore.currentPermission">
                 <FolderAddOutlined />
               </a-button>
             </a-tooltip>
             <a-tooltip title="Sửa">
-              <a-button type="link" size="small" @click="editItem(record)">
+              <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                 <EditOutlined />
               </a-button>
             </a-tooltip>
             <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
               <a-tooltip title="Xóa">
-                <a-button type="link" danger size="small">
+                <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                   <DeleteOutlined />
                 </a-button>
               </a-tooltip>
@@ -89,6 +89,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi()
 
 // --- Trạng thái hiển thị ---

--- a/pages/administration/permission.vue
+++ b/pages/administration/permission.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm Nhóm quyền..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetForm" class="w-full md:w-auto">Đặt lại</a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
     <ClientOnly class="overflow-x-auto">
@@ -19,13 +19,13 @@
           <template v-if="column.key === 'action'">
             <div class="flex justify-center">
               <div class="md:flex space-x-2">
-                <a-button type="link" size="small" @click="editItem(record.id)">
+                <a-button type="link" size="small" @click="editItem(record.id)" :disabled="!settingStore.currentPermission">
                   <template #icon>
                     <EditOutlined />
                   </template>
                 </a-button>
                 <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
-                  <a-button type="link" danger size="small">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <DeleteOutlined />
                     </template>
@@ -66,6 +66,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 import { useBreakpoints, breakpointsTailwind } from '@vueuse/core';
 const { RestApi } = useApi();
 

--- a/pages/administration/unit.vue
+++ b/pages/administration/unit.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-6">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm đơn vị..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetSearch" class="w-full md:w-auto">Đặt lại</a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
     <!-- Bảng dữ liệu -->
@@ -17,7 +17,7 @@
               <!-- Desktop view - full buttons -->
               <div class="hidden md:flex space-x-2">
                 <a-tooltip title="Sửa">
-                  <a-button type="link" size="small" @click="editItem(record)">
+                  <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <EditOutlined />
                     </template>
@@ -25,7 +25,7 @@
                 </a-tooltip>
                 <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
                   <a-tooltip title="Xóa">
-                    <a-button type="link" danger size="small">
+                    <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                       <template #icon>
                         <DeleteOutlined />
                       </template>
@@ -42,13 +42,13 @@
                   </a-button>
                   <template #overlay>
                     <a-menu>
-                      <a-menu-item key="1" @click="editItem(record)">
+                      <a-menu-item key="1" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <EditOutlined />
                         </template>
                         Sửa
                       </a-menu-item>
-                      <a-menu-item key="2" danger @click="deleteItem(record.id)">
+                      <a-menu-item key="2" danger @click="deleteItem(record.id)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <DeleteOutlined />
                         </template>
@@ -97,6 +97,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 const columns = [

--- a/pages/administration/user.vue
+++ b/pages/administration/user.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-6">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm người dùng..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetForm" class="w-full md:w-auto">Đặt lại</a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
     <ClientOnly class="overflow-x-auto">
       <a-table :columns="columns" :data-source="dataSource" :pagination="pagination" :loading="loading" :scroll="{ x: 1000 }" @change="handleTableChange" bordered size="small">
@@ -30,7 +30,7 @@
               <!-- Desktop view - full buttons -->
               <div class="hidden md:flex space-x-2">
                 <a-tooltip title="Sửa">
-                  <a-button type="link" size="small" @click="editItem(record)">
+                  <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <EditOutlined />
                     </template>
@@ -38,7 +38,7 @@
                 </a-tooltip>
                 <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
                   <a-tooltip title="Xóa">
-                    <a-button type="link" danger size="small">
+                    <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                       <template #icon>
                         <DeleteOutlined />
                       </template>
@@ -55,13 +55,13 @@
                   </a-button>
                   <template #overlay>
                     <a-menu>
-                      <a-menu-item key="1" @click="editItem(record)">
+                      <a-menu-item key="1" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <EditOutlined />
                         </template>
                         Sửa
                       </a-menu-item>
-                      <a-menu-item key="2" danger @click="deleteItem(record.id)">
+                      <a-menu-item key="2" danger @click="deleteItem(record.id)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <DeleteOutlined />
                         </template>
@@ -113,6 +113,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 const columns = [

--- a/pages/category_management/classroom.vue
+++ b/pages/category_management/classroom.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm phòng học..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetSearch" class="w-full md:w-auto">Đặt lại</a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
     <!-- Bảng dữ liệu -->
@@ -19,7 +19,7 @@
             <div class="flex justify-center gap-2">
               <div class="hidden md:flex space-x-2">
                 <a-tooltip title="Sửa">
-                  <a-button type="link" size="small" @click="editItem(record)">
+                  <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <EditOutlined />
                     </template>
@@ -27,7 +27,7 @@
                 </a-tooltip>
                 <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
                   <a-tooltip title="Xóa">
-                    <a-button type="link" danger size="small">
+                    <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                       <template #icon>
                         <DeleteOutlined />
                       </template>
@@ -42,12 +42,12 @@
                   </a-button>
                   <template #overlay>
                     <a-menu>
-                      <a-menu-item @click="editItem(record)">
+                      <a-menu-item @click="editItem(record)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <EditOutlined />
                         </template>Sửa
                       </a-menu-item>
-                      <a-menu-item danger @click="deleteItem(record.id)">
+                      <a-menu-item danger @click="deleteItem(record.id)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <DeleteOutlined />
                         </template>Xóa
@@ -86,6 +86,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });

--- a/pages/category_management/classroom_type.vue
+++ b/pages/category_management/classroom_type.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm loại phòng học..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetSearch" class="w-full md:w-auto">Đặt lại</a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
     <!-- Bảng dữ liệu -->
@@ -17,7 +17,7 @@
               <!-- Desktop view - full buttons -->
               <div class="hidden md:flex space-x-2">
                 <a-tooltip title="Sửa">
-                  <a-button type="link" size="small" @click="editItem(record)">
+                  <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <EditOutlined />
                     </template>
@@ -25,7 +25,7 @@
                 </a-tooltip>
                 <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
                   <a-tooltip title="Xóa">
-                    <a-button type="link" danger size="small">
+                    <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                       <template #icon>
                         <DeleteOutlined />
                       </template>
@@ -42,13 +42,13 @@
                   </a-button>
                   <template #overlay>
                     <a-menu>
-                      <a-menu-item key="1" @click="editItem(record)">
+                      <a-menu-item key="1" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <EditOutlined />
                         </template>
                         Sửa
                       </a-menu-item>
-                      <a-menu-item key="2" danger @click="deleteItem(record.id)">
+                      <a-menu-item key="2" danger @click="deleteItem(record.id)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <DeleteOutlined />
                         </template>
@@ -87,6 +87,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 const columns = [

--- a/pages/category_management/expertise.vue
+++ b/pages/category_management/expertise.vue
@@ -5,7 +5,7 @@
       <a-button @click="resetForm" class="w-full md:w-auto">
         <span class="md:inline">Đặt lại</span>
       </a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">
         <span class="md:inline">Thêm mới</span>
       </a-button>
     </div>
@@ -25,13 +25,13 @@
           <template v-if="column.key === 'action'">
             <div class="flex justify-center">
               <div class="md:flex space-x-2">
-                <a-button type="link" size="small" @click="editItem(record)">
+                <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                   <template #icon>
                     <EditOutlined />
                   </template>
                 </a-button>
                 <a-popconfirm placement="topRight" title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
-                  <a-button type="link" danger size="small">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <DeleteOutlined />
                     </template>
@@ -68,6 +68,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 

--- a/pages/category_management/grade_level.vue
+++ b/pages/category_management/grade_level.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm Khối lớp..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetForm" class="w-full md:w-auto">Đặt lại</a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
     <ClientOnly class="overflow-x-auto">
@@ -19,13 +19,13 @@
           <template v-if="column.key === 'action'">
             <div class="flex justify-center">
               <div class="md:flex space-x-2">
-                <a-button type="link" size="small" @click="editItem(record.id)">
+                <a-button type="link" size="small" @click="editItem(record.id)" :disabled="!settingStore.currentPermission">
                   <template #icon>
                     <EditOutlined />
                   </template>
                 </a-button>
                 <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
-                  <a-button type="link" danger size="small">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <DeleteOutlined />
                     </template>
@@ -65,6 +65,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 
 const searchText = ref('');

--- a/pages/category_management/knowledge.vue
+++ b/pages/category_management/knowledge.vue
@@ -5,7 +5,7 @@
       <a-button @click="resetForm" class="w-full md:w-auto">
         <span class="md:inline">Đặt lại</span>
       </a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">
         <span class="md:inline">Thêm mới</span>
       </a-button>
     </div>
@@ -25,13 +25,13 @@
           <template v-if="column.key === 'action'">
             <div class="flex justify-center">
               <div class="md:flex space-x-2">
-                <a-button type="link" size="small" @click="editItem(record)">
+                <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                   <template #icon>
                     <EditOutlined />
                   </template>
                 </a-button>
                 <a-popconfirm placement="topRight" title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
-                  <a-button type="link" danger size="small">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <DeleteOutlined />
                     </template>
@@ -68,6 +68,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 const columns = [

--- a/pages/category_management/school_shift.vue
+++ b/pages/category_management/school_shift.vue
@@ -6,7 +6,7 @@
       <a-button @click="resetForm" class="w-full md:w-auto">
         <span class="md:inline">Đặt lại</span>
       </a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">
         <span class="md:inline">Thêm mới</span>
       </a-button>
     </div>
@@ -26,13 +26,13 @@
           <template v-if="column.key === 'action'">
             <div class="flex justify-center">
               <div class="md:flex space-x-2">
-                <a-button type="link" size="small" @click="editItem(record)">
+                <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                   <template #icon>
                     <EditOutlined />
                   </template>
                 </a-button>
                 <a-popconfirm placement="topRight" title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
-                  <a-button type="link" danger size="small">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <DeleteOutlined />
                     </template>
@@ -68,6 +68,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 const columns = [

--- a/pages/category_management/school_site.vue
+++ b/pages/category_management/school_site.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-6">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm điểm trường..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetSearch" class="w-full md:w-auto">Đặt lại</a-button>
-      <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
     <!-- Bảng dữ liệu -->
     <ClientOnly>
@@ -16,7 +16,7 @@
               <!-- Desktop view - full buttons -->
               <div class="hidden md:flex space-x-2">
                 <a-tooltip title="Sửa">
-                  <a-button type="link" size="small" @click="editItem(record)">
+                  <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                     <template #icon>
                       <EditOutlined />
                     </template>
@@ -24,7 +24,7 @@
                 </a-tooltip>
                 <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
                   <a-tooltip title="Xóa">
-                    <a-button type="link" danger size="small">
+                    <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
                       <template #icon>
                         <DeleteOutlined />
                       </template>
@@ -41,13 +41,13 @@
                   </a-button>
                   <template #overlay>
                     <a-menu>
-                      <a-menu-item key="1" @click="editItem(record)">
+                      <a-menu-item key="1" @click="editItem(record)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <EditOutlined />
                         </template>
                         Sửa
                       </a-menu-item>
-                      <a-menu-item key="2" danger @click="deleteItem(record.id)">
+                      <a-menu-item key="2" danger @click="deleteItem(record.id)" :disabled="!settingStore.currentPermission">
                         <template #icon>
                           <DeleteOutlined />
                         </template>
@@ -86,6 +86,7 @@
 </template>
 
 <script setup>
+const settingStore = useSettingStore();
 const { RestApi } = useApi();
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 const columns = [


### PR DESCRIPTION
## Summary
- disable create/edit/delete buttons when currentPermission is false

## Testing
- `yarn build` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684fea15a04c8331b8956d33b7bb03f1