### PR TITLE
Add school period management

### DIFF
--- a/components/Select/SchoolDay.vue
+++ b/components/Select/SchoolDay.vue
@@ -1,0 +1,76 @@
+<template>
+  <a-form-item :label="label" :name="name" :rules="rules">
+    <a-select
+      :value="modelValue"
+      @update:value="val => $emit('update:modelValue', val)"
+      :mode="multiple ? 'multiple' : undefined"
+      show-search
+      :placeholder="placeholder"
+      :loading="loading"
+      :disabled="disabled"
+      allow-clear
+      class="w-full"
+      :options="options"
+      @search="onSearch"
+      :filter-option="false"
+    />
+  </a-form-item>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import debounce from 'lodash/debounce'
+
+const { RestApi } = useApi()
+
+const props = defineProps({
+  modelValue: [Array, Number, String],
+  label: { type: String, default: 'Ngày học' },
+  name: { type: String, default: 'ngayhoc' },
+  multiple: { type: Boolean, default: false },
+  placeholder: { type: String, default: 'Chọn ngày học' },
+  rules: { type: Array, default: () => [] },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const options = ref([])
+const loading = ref(false)
+
+const fetchDays = async (search = '') => {
+  loading.value = true
+  try {
+    const { data } = await RestApi.school_day.list({ params: { search } })
+
+    if (data.value?.data?.items) {
+      options.value = data.value.data.items.map(item => ({
+        label: item.ten,
+        value: item.id,
+      }))
+
+      if (
+        props.modelValue === undefined ||
+        props.modelValue === null ||
+        props.modelValue === ''
+      ) {
+        emit('update:modelValue', props.modelValue)
+      }
+    }
+  } catch (err) {
+    console.error('❌ Lỗi fetch ngày học:', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+const debouncedFetch = debounce((val) => {
+  fetchDays(val.trim())
+}, 300)
+
+const onSearch = (val) => {
+  debouncedFetch(val)
+}
+
+await fetchDays()
+</script>

--- a/components/Select/SchoolPeriod.vue
+++ b/components/Select/SchoolPeriod.vue
@@ -1,0 +1,76 @@
+<template>
+  <a-form-item :label="label" :name="name" :rules="rules">
+    <a-select
+      :value="modelValue"
+      @update:value="val => $emit('update:modelValue', val)"
+      :mode="multiple ? 'multiple' : undefined"
+      show-search
+      :placeholder="placeholder"
+      :loading="loading"
+      :disabled="disabled"
+      allow-clear
+      class="w-full"
+      :options="options"
+      @search="onSearch"
+      :filter-option="false"
+    />
+  </a-form-item>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import debounce from 'lodash/debounce'
+
+const { RestApi } = useApi()
+
+const props = defineProps({
+  modelValue: [Array, Number, String],
+  label: { type: String, default: 'Tiết học' },
+  name: { type: String, default: 'tiethoc' },
+  multiple: { type: Boolean, default: false },
+  placeholder: { type: String, default: 'Chọn tiết học' },
+  rules: { type: Array, default: () => [] },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const options = ref([])
+const loading = ref(false)
+
+const fetchPeriods = async (search = '') => {
+  loading.value = true
+  try {
+    const { data } = await RestApi.school_period.list({ params: { search } })
+
+    if (data.value?.data?.items) {
+      options.value = data.value.data.items.map(item => ({
+        label: item.ten,
+        value: item.id,
+      }))
+
+      if (
+        props.modelValue === undefined ||
+        props.modelValue === null ||
+        props.modelValue === ''
+      ) {
+        emit('update:modelValue', props.modelValue)
+      }
+    }
+  } catch (err) {
+    console.error('❌ Lỗi fetch tiết học:', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+const debouncedFetch = debounce((val) => {
+  fetchPeriods(val.trim())
+}, 300)
+
+const onSearch = (val) => {
+  debouncedFetch(val)
+}
+
+await fetchPeriods()
+</script>

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -34,6 +34,9 @@ let ENDPOINTS = {
   //CLASSROOM
   CLASSROOM: "/api/phonghoc",
   CLASSROOM_DETAIL: "/api/phonghoc/detail",
+  //SCHOOL_PERIOD
+  SCHOOL_PERIOD: "/api/tiethoc",
+  SCHOOL_PERIOD_DETAIL: "/api/tiethoc/detail",
 
   S3: "/api/presigned_url",
 };
@@ -129,6 +132,7 @@ class RestApi {
     this.grade_level = new GradeLevel(this.request);
     this.roles = new Roles(this.request);
     this.classroom = new Classroom(this.request);
+    this.school_period = new SchoolPeriod(this.request);
   }
   async get_url_upload(acl, content_encoding, content_type, key, platform) {
     let data = { acl, content_encoding, content_type, key, platform };
@@ -415,6 +419,26 @@ class Classroom {
   }
   async delete(data) {
     return await this.request.delete(ENDPOINTS.CLASSROOM, data);
+  }
+}
+class SchoolPeriod {
+  constructor() {
+    this.request = new Request();
+  }
+  async list(data) {
+    return await this.request.get(ENDPOINTS.SCHOOL_PERIOD, data);
+  }
+  async detail(data) {
+    return await this.request.get(ENDPOINTS.SCHOOL_PERIOD_DETAIL, data);
+  }
+  async create(data) {
+    return await this.request.post(ENDPOINTS.SCHOOL_PERIOD, data);
+  }
+  async update(data) {
+    return await this.request.put(ENDPOINTS.SCHOOL_PERIOD, data);
+  }
+  async delete(data) {
+    return await this.request.delete(ENDPOINTS.SCHOOL_PERIOD, data);
   }
 }
 export default () => {

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -37,6 +37,9 @@ let ENDPOINTS = {
   //SCHOOL_PERIOD
   SCHOOL_PERIOD: "/api/tiethoc",
   SCHOOL_PERIOD_DETAIL: "/api/tiethoc/detail",
+  //SCHOOL_DAY
+  SCHOOL_DAY: "/api/ngayhoc",
+  SCHOOL_DAY_DETAIL: "/api/ngayhoc/detail",
 
   S3: "/api/presigned_url",
 };
@@ -132,6 +135,7 @@ class RestApi {
     this.grade_level = new GradeLevel(this.request);
     this.roles = new Roles(this.request);
     this.classroom = new Classroom(this.request);
+    this.school_day = new SchoolDay(this.request);
     this.school_period = new SchoolPeriod(this.request);
   }
   async get_url_upload(acl, content_encoding, content_type, key, platform) {
@@ -419,6 +423,26 @@ class Classroom {
   }
   async delete(data) {
     return await this.request.delete(ENDPOINTS.CLASSROOM, data);
+  }
+}
+class SchoolDay {
+  constructor() {
+    this.request = new Request();
+  }
+  async list(data) {
+    return await this.request.get(ENDPOINTS.SCHOOL_DAY, data);
+  }
+  async detail(data) {
+    return await this.request.get(ENDPOINTS.SCHOOL_DAY_DETAIL, data);
+  }
+  async create(data) {
+    return await this.request.post(ENDPOINTS.SCHOOL_DAY, data);
+  }
+  async update(data) {
+    return await this.request.put(ENDPOINTS.SCHOOL_DAY, data);
+  }
+  async delete(data) {
+    return await this.request.delete(ENDPOINTS.SCHOOL_DAY, data);
   }
 }
 class SchoolPeriod {

--- a/pages/category_management/school_day.vue
+++ b/pages/category_management/school_day.vue
@@ -1,0 +1,249 @@
+<template>
+  <div class="p-2 md:p-4 bg-white min-h-full">
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
+      <a-input-search v-model:value="searchText" placeholder="Tìm kiếm ngày học..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
+      <a-button @click="resetForm" class="w-full md:w-auto">
+        <span class="md:inline">Đặt lại</span>
+      </a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">
+        <span class="md:inline">Thêm mới</span>
+      </a-button>
+    </div>
+
+    <ClientOnly class="overflow-x-auto">
+      <a-table :columns="columns" :data-source="dataSource" :pagination="pagination" :loading="loading" :scroll="{ x: '800' }" @change="handleTableChange" bordered size="small">
+        <template #bodyCell="{ column, record, index }">
+          <template v-if="column.key === 'stt'">
+            {{ (pagination.current - 1) * pagination.pageSize + index + 1 }}
+          </template>
+
+          <template v-if="column.key === 'ghi_chu'">
+            <span v-if="record.ghi_chu">{{ record.ghi_chu }}</span>
+            <span v-else class="text-gray-400">Trống</span>
+          </template>
+
+          <template v-if="column.key === 'action'">
+            <div class="flex justify-center">
+              <div class="md:flex space-x-2">
+                <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
+                  <template #icon>
+                    <EditOutlined />
+                  </template>
+                </a-button>
+                <a-popconfirm placement="topRight" title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
+                    <template #icon>
+                      <DeleteOutlined />
+                    </template>
+                  </a-button>
+                </a-popconfirm>
+              </div>
+            </div>
+          </template>
+        </template>
+      </a-table>
+    </ClientOnly>
+
+    <a-modal v-model:open="visible" :title="isEdit ? 'Chỉnh sửa ngày học' : 'Thêm mới ngày học'" @cancel="handleCancel" :width="600">
+      <a-form ref="formRef" :model="formState" layout="vertical" :rules="rules">
+        <a-form-item label="Tên ngày học" name="ten" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }">
+          <a-input v-model:value="formState.ten" placeholder="Nhập tên ngày học" :maxlength="200" show-count />
+        </a-form-item>
+
+        <a-form-item label="Ghi chú" name="ghi_chu" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }">
+          <a-textarea v-model:value="formState.ghi_chu" :rows="4" placeholder="Nhập ghi chú (nếu có)" :maxlength="200" show-count />
+        </a-form-item>
+      </a-form>
+
+      <template #footer>
+        <div class="flex justify-end space-x-2">
+          <a-button @click="handleCancel">Hủy</a-button>
+          <a-button type="primary" @click="handleOk" :loading="confirmLoading">
+            {{ isEdit ? 'Cập nhật' : 'Thêm mới' }}
+          </a-button>
+        </div>
+      </template>
+    </a-modal>
+  </div>
+</template>
+
+<script setup>
+const settingStore = useSettingStore();
+const { RestApi } = useApi();
+const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
+const columns = [
+  {
+    title: 'STT',
+    key: 'stt',
+    width: 50,
+    align: 'center',
+  },
+  {
+    title: 'Tên ngày học',
+    dataIndex: 'ten',
+    key: 'ten',
+    ellipsis: true
+  },
+  {
+    title: 'Ghi chú',
+    dataIndex: 'ghi_chu',
+    key: 'ghi_chu',
+    ellipsis: true
+  },
+  {
+    title: 'Thao tác',
+    key: 'action',
+    width: 80,
+    align: 'center',
+    fixed: 'right'
+  }
+]
+
+const dataSource = ref([])
+const loading = ref(false)
+const searchText = ref('')
+const visible = ref(false)
+const confirmLoading = ref(false)
+const isEdit = ref(false)
+const formRef = ref()
+
+const pagination = reactive({
+  current: 1,
+  pageSize: 10,
+  total: 0,
+  showSizeChanger: true,
+  pageSizeOptions: ['1', '10', '20', '50'],
+  showTotal: (total) => `Tổng ${total} bản ghi`
+})
+
+const formState = reactive({
+  ten: '',
+  ghi_chu: ''
+})
+
+const rules = reactive({
+  ten: [
+    { required: true, message: 'Vui lòng nhập tên ngày học', trigger: 'blur' },
+    { min: 2, message: 'Tên phải có ít nhất 2 ký tự', trigger: 'blur' }
+  ]
+})
+
+const fetchData = async (param) => {
+  try {
+    loading.value = true
+    const { data } = await RestApi.school_day.list({ params: param })
+    if (data.value?.status === 'success') {
+      dataSource.value = data.value.data.items || []
+      pagination.total = data.value.data.totalrecord
+    } else {
+      dataSource.value = []
+      pagination.total = 0
+    }
+  } catch (error) {
+    console.error('Error fetching data:', error)
+    message.error('Lỗi khi tải dữ liệu')
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleTableChange = async (pag) => {
+  pagination.current = pag.current
+  pagination.pageSize = pag.pageSize
+  param.value.PageIndex = pag.current
+  param.value.PageSize = pag.pageSize
+  await fetchData({ ...param.value })
+}
+
+const handleSearch = async () => {
+  param.value.search = searchText.value
+  pagination.current = 1
+  await fetchData({ ...param.value })
+}
+
+const showModal = () => {
+  isEdit.value = false
+  Object.assign(formState, {
+    ten: '',
+    ghi_chu: ''
+  })
+  visible.value = true
+}
+
+const editItem = (record) => {
+  isEdit.value = true
+  Object.assign(formState, {
+    id: record.id,
+    ten: record.ten,
+    ghi_chu: record.ghi_chu || ''
+  })
+  visible.value = true
+}
+
+const handleOk = async () => {
+  try {
+    await formRef.value.validate()
+    confirmLoading.value = true
+    if (isEdit.value) {
+      const { data, error } = await RestApi.school_day.update({ body: { ...formState } })
+      if (data.value?.status === 'success') {
+        message.success(data.value?.message || "Cập nhật ngày học thành công")
+      } else {
+        throw new Error(error.value?.data?.message || 'Cập nhật không thành công')
+      }
+    } else {
+      if (formState) {
+        delete formState.id
+      }
+      const { data, error } = await RestApi.school_day.create({ body: { ...formState } })
+      if (data.value?.status === 'success') {
+        message.success(data.value?.message || "Tạo mới ngày học thành công")
+      } else {
+        throw new Error(error.value?.data?.message || 'Thêm mới không thành công')
+      }
+    }
+  } catch (error) {
+    message.error(error.message || error.response?.data?.message || 'Đã xảy ra lỗi khi lưu thông tin')
+  } finally {
+    await fetchData({ ...param.value })
+    confirmLoading.value = false
+    visible.value = false
+    formRef.value.resetFields()
+  }
+}
+
+const handleCancel = () => {
+  formRef.value.resetFields()
+  visible.value = false
+}
+
+const deleteItem = async (id) => {
+  try {
+    const { data } = await RestApi.school_day.delete({ params: { id: id } })
+    if (data.value?.status === 'success') {
+      message.success(data.value?.message || 'Xóa thành công')
+    } else {
+      message.error(data.value?.message || 'Có lỗi xảy ra')
+    }
+  } catch (error) {
+    console.error('Error deleting data:', error)
+    message.error('Có lỗi xảy ra khi xóa dữ liệu')
+  } finally {
+    await fetchData({ ...param.value })
+  }
+}
+
+const resetForm = async () => {
+  if (formRef.value) {
+    formRef.value.resetFields();
+  }
+  param.value.PageIndex = 1;
+  param.value.PageSize = 10;
+  param.value.search = "";
+  pagination.current = 1;
+  pagination.pageSize = 10;
+  await fetchData({ ...param.value })
+}
+
+await fetchData({ ...param.value })
+</script>

--- a/pages/category_management/school_period.vue
+++ b/pages/category_management/school_period.vue
@@ -1,0 +1,223 @@
+<template>
+  <div class="p-2 md:p-4 bg-white min-h-full">
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
+      <a-input-search
+        v-model:value="searchText"
+        placeholder="Tìm kiếm tiết học..."
+        enter-button
+        @search="handleSearch"
+        class="w-full md:w-1/3"
+      />
+      <a-button @click="resetForm" class="w-full md:w-auto">
+        <span class="md:inline">Đặt lại</span>
+      </a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">
+        <span class="md:inline">Thêm mới</span>
+      </a-button>
+    </div>
+
+    <ClientOnly class="overflow-x-auto">
+      <a-table
+        :columns="columns"
+        :data-source="dataSource"
+        :pagination="pagination"
+        :loading="loading"
+        :scroll="{ x: '800' }"
+        @change="handleTableChange"
+        bordered
+        size="small"
+      >
+        <template #bodyCell="{ column, record, index }">
+          <template v-if="column.key === 'stt'">
+            {{ (pagination.current - 1) * pagination.pageSize + index + 1 }}
+          </template>
+          <template v-if="column.key === 'action'">
+            <div class="flex justify-center">
+              <div class="md:flex space-x-2">
+                <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
+                  <template #icon>
+                    <EditOutlined />
+                  </template>
+                </a-button>
+                <a-popconfirm placement="topRight" title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
+                    <template #icon>
+                      <DeleteOutlined />
+                    </template>
+                  </a-button>
+                </a-popconfirm>
+              </div>
+            </div>
+          </template>
+        </template>
+      </a-table>
+    </ClientOnly>
+
+    <a-modal v-model:open="visible" :title="isEdit ? 'Chỉnh sửa tiết học' : 'Thêm mới tiết học'" @cancel="handleCancel" :width="600">
+      <a-form ref="formRef" :model="formState" layout="vertical" :rules="rules">
+        <a-form-item label="Tên tiết học" name="ten" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }">
+          <a-input v-model:value="formState.ten" placeholder="Nhập tên tiết học" :maxlength="200" show-count />
+        </a-form-item>
+        <SelectSchoolShift v-model="formState.id_ca_hoc" name="id_ca_hoc" :multiple="true" :rules="rules.id_ca_hoc" />
+      </a-form>
+
+      <template #footer>
+        <div class="flex justify-end space-x-2">
+          <a-button @click="handleCancel">Hủy</a-button>
+          <a-button type="primary" @click="handleOk" :loading="confirmLoading">
+            {{ isEdit ? 'Cập nhật' : 'Thêm mới' }}
+          </a-button>
+        </div>
+      </template>
+    </a-modal>
+  </div>
+</template>
+
+<script setup>
+const settingStore = useSettingStore();
+const { RestApi } = useApi();
+const param = ref({ PageIndex: 1, PageSize: 10, search: '' });
+
+const columns = [
+  { title: 'STT', key: 'stt', width: 50, align: 'center' },
+  { title: 'Tên tiết học', dataIndex: 'ten', key: 'ten', ellipsis: true },
+  { title: 'Thao tác', key: 'action', width: 80, align: 'center', fixed: 'right' }
+];
+
+const dataSource = ref([]);
+const loading = ref(false);
+const searchText = ref('');
+const visible = ref(false);
+const confirmLoading = ref(false);
+const isEdit = ref(false);
+const formRef = ref();
+
+const pagination = reactive({
+  current: 1,
+  pageSize: 10,
+  total: 0,
+  showSizeChanger: true,
+  pageSizeOptions: ['1', '10', '20', '50'],
+  showTotal: (total) => `Tổng ${total} bản ghi`
+});
+
+const formState = reactive({
+  id: null,
+  ten: '',
+  id_ca_hoc: []
+});
+
+const rules = reactive({
+  ten: [
+    { required: true, message: 'Vui lòng nhập tên tiết học', trigger: 'blur' },
+    { min: 2, message: 'Tên phải có ít nhất 2 ký tự', trigger: 'blur' }
+  ],
+  id_ca_hoc: [
+    { required: true, message: 'Vui lòng chọn ca học', trigger: 'blur', type: 'array' }
+  ]
+});
+
+const fetchData = async (param) => {
+  try {
+    loading.value = true;
+    const { data } = await RestApi.school_period.list({ params: param });
+    if (data.value?.status === 'success') {
+      dataSource.value = data.value.data.items || [];
+      pagination.total = data.value.data.totalrecord;
+    } else {
+      dataSource.value = [];
+      pagination.total = 0;
+    }
+  } catch (error) {
+    console.error('Error fetching data:', error);
+    message.error('Lỗi khi tải dữ liệu');
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleTableChange = async (pag) => {
+  pagination.current = pag.current;
+  pagination.pageSize = pag.pageSize;
+  param.value.PageIndex = pag.current;
+  param.value.PageSize = pag.pageSize;
+  await fetchData({ ...param.value });
+};
+
+const handleSearch = async () => {
+  param.value.search = searchText.value;
+  pagination.current = 1;
+  await fetchData({ ...param.value });
+};
+
+const showModal = () => {
+  isEdit.value = false;
+  Object.assign(formState, { id: null, ten: '', id_ca_hoc: [] });
+  visible.value = true;
+};
+
+const editItem = (record) => {
+  isEdit.value = true;
+  Object.assign(formState, {
+    id: record.id,
+    ten: record.ten,
+    id_ca_hoc: record.id_ca_hoc || []
+  });
+  visible.value = true;
+};
+
+const handleOk = async () => {
+  try {
+    await formRef.value.validate();
+    confirmLoading.value = true;
+    let res;
+    if (isEdit.value) {
+      res = await RestApi.school_period.update({ body: { ...formState } });
+    } else {
+      if (formState.id !== null) delete formState.id;
+      res = await RestApi.school_period.create({ body: { ...formState } });
+    }
+    if (res.data.value?.status === 'success') {
+      message.success(res.data.value?.message || 'Thành công');
+      await fetchData({ ...param.value });
+      visible.value = false;
+      formRef.value.resetFields();
+    } else {
+      throw new Error(res.error?.value?.data?.message || 'Lỗi không xác định');
+    }
+  } catch (err) {
+    message.error(err.message || 'Lỗi khi lưu thông tin');
+  } finally {
+    confirmLoading.value = false;
+  }
+};
+
+const handleCancel = () => {
+  formRef.value.resetFields();
+  visible.value = false;
+};
+
+const deleteItem = async (id) => {
+  try {
+    const { data } = await RestApi.school_period.delete({ params: { id } });
+    if (data.value?.status === 'success') {
+      message.success(data.value?.message || 'Đã xóa');
+      await fetchData({ ...param.value });
+    } else {
+      message.error(data.value?.message || 'Không thể xóa');
+    }
+  } catch (err) {
+    message.error('Lỗi khi xóa');
+  }
+};
+
+const resetForm = async () => {
+  if (formRef.value) formRef.value.resetFields();
+  param.value = { PageIndex: 1, PageSize: 10, search: '' };
+  pagination.current = 1;
+  pagination.pageSize = 10;
+  await fetchData({ ...param.value });
+};
+
+await fetchData({ ...param.value });
+</script>

--- a/pages/category_management/school_period.vue
+++ b/pages/category_management/school_period.vue
@@ -102,7 +102,6 @@ const pagination = reactive({
 });
 
 const formState = reactive({
-  id: null,
   ten: '',
   id_ca_hoc: []
 });
@@ -152,7 +151,7 @@ const handleSearch = async () => {
 
 const showModal = () => {
   isEdit.value = false;
-  Object.assign(formState, { id: null, ten: '', id_ca_hoc: [] });
+  Object.assign(formState, { ten: '', id_ca_hoc: [] });
   visible.value = true;
 };
 
@@ -182,7 +181,7 @@ const handleOk = async () => {
     if (isEdit.value) {
       res = await RestApi.school_period.update({ body: { ...formState } });
     } else {
-      if (formState.id !== null) delete formState.id;
+      if (formState.id) delete formState.id;
       res = await RestApi.school_period.create({ body: { ...formState } });
     }
     if (res.data.value?.status === 'success') {

--- a/pages/category_management/school_period.vue
+++ b/pages/category_management/school_period.vue
@@ -156,14 +156,22 @@ const showModal = () => {
   visible.value = true;
 };
 
-const editItem = (record) => {
+const editItem = async (record) => {
   isEdit.value = true;
-  Object.assign(formState, {
-    id: record.id,
-    ten: record.ten,
-    id_ca_hoc: record.id_ca_hoc || []
-  });
-  visible.value = true;
+  try {
+    const { data } = await RestApi.school_period.detail({ params: { id: record.id } });
+    if (data.value?.status === 'success') {
+      const detail = data.value.data;
+      Object.assign(formState, {
+        id: detail.id,
+        ten: detail.ten,
+        id_ca_hoc: detail.id_Ca_hoc || []
+      });
+      visible.value = true;
+    }
+  } catch (err) {
+    message.error('Không thể lấy dữ liệu chi tiết');
+  }
 };
 
 const handleOk = async () => {

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -9,6 +9,9 @@
     <a-button type="primary" class="font-roboto w-full md:w-auto" @click="() => { navigateTo('/demo/tiethoc') }">
       Demo: SelectSchoolPeriod (Tiết học)
     </a-button>
+    <a-button type="primary" class="font-roboto w-full md:w-auto" @click="() => { navigateTo('/demo/ngayhoc') }">
+      Demo: SelectSchoolDay (Ngày học)
+    </a-button>
     <a-button type="primary" class="font-roboto w-full md:w-auto" @click="() => { navigateTo('/demo/diemtruong') }">
       Demo: SelectSchoolSite (Điểm trường)
     </a-button>

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -6,6 +6,9 @@
     <a-button type="primary" class="font-roboto w-full md:w-auto" @click="() => { navigateTo('/demo/cahoc') }">
       Demo: SelectSchoolShift (Ca Học)
     </a-button>
+    <a-button type="primary" class="font-roboto w-full md:w-auto" @click="() => { navigateTo('/demo/tiethoc') }">
+      Demo: SelectSchoolPeriod (Tiết học)
+    </a-button>
     <a-button type="primary" class="font-roboto w-full md:w-auto" @click="() => { navigateTo('/demo/diemtruong') }">
       Demo: SelectSchoolSite (Điểm trường)
     </a-button>

--- a/pages/demo/ngayhoc.vue
+++ b/pages/demo/ngayhoc.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="max-w-3xl mx-auto p-6 space-y-6">
+    <h1 class="text-2xl font-bold">Demo: SelectSchoolDay (Ngày học)</h1>
+
+    <ClientOnly>
+      <a-form :model="form" @finish="submit" layout="vertical">
+        <SelectSchoolDay
+          v-model="form.dayMultiple"
+          label="Chọn nhiều ngày học"
+          name="dayMultiple"
+          :multiple="true"
+        />
+
+        <SelectSchoolDay
+          v-model="form.daySingle"
+          label="Chọn một ngày học"
+          name="daySingle"
+        />
+
+        <SelectSchoolDay
+          v-model="form.dayDisabled"
+          label="Ngày học bị khóa"
+          name="dayDisabled"
+          :disabled="true"
+        />
+
+        <a-button type="dashed" @click="modalOpen = true">Chọn ngày học trong Modal</a-button>
+
+        <a-button html-type="submit" type="primary" class="mt-4">Gửi</a-button>
+      </a-form>
+
+      <a-modal v-model:open="modalOpen" title="Chọn ngày học" @ok="submitModal">
+        <SelectSchoolDay
+          v-model="modalForm.modalDay"
+          label="Ngày học modal"
+          name="modalDay"
+        />
+      </a-modal>
+
+      <div class="mt-6">
+        <h2 class="font-semibold">📦 Form:</h2>
+        <pre class="bg-gray-100 p-4 rounded"><code>{{ form }}</code></pre>
+        <h2 class="font-semibold mt-2">🧪 Modal:</h2>
+        <pre class="bg-gray-100 p-4 rounded"><code>{{ modalForm }}</code></pre>
+      </div>
+
+      <div class="mt-10 border-t pt-6">
+        <h2 class="text-xl font-bold mb-4">📘 Hướng dẫn sử dụng & Props</h2>
+        <a-table :columns="columns" :data-source="propsTable" bordered size="small" row-key="prop" />
+      </div>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup>
+const form = reactive({
+  dayMultiple: [1],
+  daySingle: null,
+  dayDisabled: 1,
+})
+
+const modalForm = reactive({
+  modalDay: null,
+})
+
+const modalOpen = ref(false)
+
+const submit = () => {
+  console.log('📤 Form:', form)
+}
+
+const submitModal = () => {
+  console.log('📤 Modal:', modalForm)
+  modalOpen.value = false
+}
+
+const columns = [
+  { title: 'Prop', dataIndex: 'prop' },
+  { title: 'Kiểu', dataIndex: 'type' },
+  { title: 'Mặc định', dataIndex: 'default' },
+  { title: 'Mô tả', dataIndex: 'desc' },
+]
+
+const propsTable = [
+  { prop: 'modelValue', type: 'Array | Number | String', default: '—', desc: 'Giá trị binding qua v-model' },
+  { prop: 'label', type: 'String', default: 'Ngày học', desc: 'Nhãn hiển thị trên form item' },
+  { prop: 'name', type: 'String', default: 'ngayhoc', desc: 'Tên trường trong form' },
+  { prop: 'multiple', type: 'Boolean', default: 'false', desc: 'Cho phép chọn nhiều giá trị hay không' },
+  { prop: 'placeholder', type: 'String', default: 'Chọn ngày học', desc: 'Placeholder hiển thị khi chưa chọn' },
+  { prop: 'rules', type: 'Array', default: '[]', desc: 'Mảng rule kiểm tra hợp lệ (validate)' },
+  { prop: 'disabled', type: 'Boolean', default: 'false', desc: 'Không cho người dùng tương tác nếu true' },
+]
+</script>

--- a/pages/demo/tiethoc.vue
+++ b/pages/demo/tiethoc.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="max-w-3xl mx-auto p-6 space-y-6">
+    <h1 class="text-2xl font-bold">Demo: SelectSchoolPeriod (Tiết học)</h1>
+
+    <ClientOnly>
+      <a-form :model="form" @finish="submit" layout="vertical">
+        <SelectSchoolPeriod
+          v-model="form.periodMultiple"
+          label="Chọn nhiều tiết học"
+          name="periodMultiple"
+          :multiple="true"
+        />
+
+        <SelectSchoolPeriod
+          v-model="form.periodSingle"
+          label="Chọn một tiết học"
+          name="periodSingle"
+        />
+
+        <SelectSchoolPeriod
+          v-model="form.periodDisabled"
+          label="Tiết học bị khóa"
+          name="periodDisabled"
+          :disabled="true"
+        />
+
+        <a-button type="dashed" @click="modalOpen = true">Chọn tiết học trong Modal</a-button>
+
+        <a-button html-type="submit" type="primary" class="mt-4">Gửi</a-button>
+      </a-form>
+
+      <a-modal v-model:open="modalOpen" title="Chọn tiết học" @ok="submitModal">
+        <SelectSchoolPeriod
+          v-model="modalForm.modalPeriod"
+          label="Tiết học modal"
+          name="modalPeriod"
+        />
+      </a-modal>
+
+      <div class="mt-6">
+        <h2 class="font-semibold">📦 Form:</h2>
+        <pre class="bg-gray-100 p-4 rounded"><code>{{ form }}</code></pre>
+        <h2 class="font-semibold mt-2">🧪 Modal:</h2>
+        <pre class="bg-gray-100 p-4 rounded"><code>{{ modalForm }}</code></pre>
+      </div>
+
+      <div class="mt-10 border-t pt-6">
+        <h2 class="text-xl font-bold mb-4">📘 Hướng dẫn sử dụng & Props</h2>
+        <a-table :columns="columns" :data-source="propsTable" bordered size="small" row-key="prop" />
+      </div>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup>
+const form = reactive({
+  periodMultiple: [1],
+  periodSingle: null,
+  periodDisabled: 1,
+})
+
+const modalForm = reactive({
+  modalPeriod: null,
+})
+
+const modalOpen = ref(false)
+
+const submit = () => {
+  console.log('📤 Form:', form)
+}
+
+const submitModal = () => {
+  console.log('📤 Modal:', modalForm)
+  modalOpen.value = false
+}
+
+const columns = [
+  { title: 'Prop', dataIndex: 'prop' },
+  { title: 'Kiểu', dataIndex: 'type' },
+  { title: 'Mặc định', dataIndex: 'default' },
+  { title: 'Mô tả', dataIndex: 'desc' },
+]
+
+const propsTable = [
+  { prop: 'modelValue', type: 'Array | Number | String', default: '—', desc: 'Giá trị binding qua v-model' },
+  { prop: 'label', type: 'String', default: 'Tiết học', desc: 'Nhãn hiển thị trên form item' },
+  { prop: 'name', type: 'String', default: 'tiethoc', desc: 'Tên trường trong form' },
+  { prop: 'multiple', type: 'Boolean', default: 'false', desc: 'Cho phép chọn nhiều giá trị hay không' },
+  { prop: 'placeholder', type: 'String', default: 'Chọn tiết học', desc: 'Placeholder hiển thị khi chưa chọn' },
+  { prop: 'rules', type: 'Array', default: '[]', desc: 'Mảng rule kiểm tra hợp lệ (validate)' },
+  { prop: 'disabled', type: 'Boolean', default: 'false', desc: 'Không cho người dùng tương tác nếu true' },
+]
+</script>


### PR DESCRIPTION
## Summary
- support `tiethoc` API endpoints
- add `SchoolPeriod` select component
- create category management page for SchoolPeriod
- demo usage on new page
- add shortcut on dashboard

## Testing
- `yarn lint` *(fails: fetch failed due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_6850dd30cdb48331816376e71db03701