### PR TITLE
Add AntD icon picker

### DIFF
--- a/components/IconPicker.vue
+++ b/components/IconPicker.vue
@@ -1,0 +1,53 @@
+<template>
+  <a-form-item :label="label" :name="name" :rules="rules">
+    <a-select
+      show-search
+      class="w-full"
+      :value="modelValue"
+      @update:value="val => $emit('update:modelValue', val)"
+      :placeholder="placeholder"
+      allow-clear
+      :options="filteredOptions"
+      :filter-option="false"
+      @search="onSearch"
+    >
+      <template #option="{ value }">
+        <div class="flex items-center gap-2">
+          <Icon :name="value" />
+          <span>{{ value.replace('ant-design:', '') }}</span>
+        </div>
+      </template>
+    </a-select>
+  </a-form-item>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import icons from '@iconify-json/ant-design/icons.json'
+
+const props = defineProps({
+  modelValue: String,
+  label: { type: String, default: 'Icon' },
+  name: { type: String, default: 'icon' },
+  placeholder: { type: String, default: 'Chọn icon' },
+  rules: { type: Array, default: () => [] }
+})
+
+const emit = defineEmits(['update:modelValue'])
+const search = ref('')
+
+const allOptions = Object.keys(icons.icons).map(name => ({
+  label: name,
+  value: `ant-design:${name}`
+}))
+
+const filteredOptions = computed(() => {
+  if (!search.value) return allOptions
+  const keyword = search.value.toLowerCase()
+  return allOptions.filter(i => i.label.toLowerCase().includes(keyword))
+})
+
+const onSearch = val => {
+  search.value = val
+}
+</script>

--- a/pages/administration/menu.vue
+++ b/pages/administration/menu.vue
@@ -65,9 +65,7 @@
         <a-form-item label="Đường dẫn" name="url">
           <a-input v-model:value="formState.url" />
         </a-form-item>
-        <a-form-item label="Icon" name="icon">
-          <a-input v-model:value="formState.icon" />
-        </a-form-item>
+        <IconPicker v-model="formState.icon" />
         <!-- <a-form-item label="Menu cha" v-if="!currentParentId">
           <a-tree-select
             v-model:value="formState.parent_Id"


### PR DESCRIPTION
## Summary
- add new `IconPicker` component built from `@iconify-json/ant-design`
- use `IconPicker` when editing menu items so icons are chosen from AntD set only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68529450c17c8331ad7b19bd167958f2