### PR TITLE
Add busy period manager to classroom page

### DIFF
--- a/pages/category_management/classroom.vue
+++ b/pages/category_management/classroom.vue
@@ -4,6 +4,7 @@
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
       <a-input-search v-model:value="searchText" placeholder="Tìm kiếm phòng học..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetSearch" class="w-full md:w-auto">Đặt lại</a-button>
+      <a-button @click="openBusyManager" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Cài đặt tiết bận</a-button>
       <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
@@ -103,14 +104,30 @@
         <a-button type="primary" @click="handleBusyOk" :loading="confirmLoading">Cập Nhật</a-button>
       </div>
     </a-modal>
+    <a-modal v-model:open="busy_manager_modal" title="Cài đặt tiết bận" @cancel="closeBusyManager" :width="800" :footer="null">
+      <a-table :columns="busyColumns" :data-source="dataSource" :pagination="false" bordered size="small" />
+      <div v-if="selectedClassroom && busy_data" class="mt-4">
+        <h3 class="font-medium mb-2">{{ selectedClassroom.ten }}</h3>
+        <div v-for="(block) in busy_data.ds_Ca" :key="block.id" style="margin-bottom: 2rem;">
+          <Timetable :block="block" />
+        </div>
+        <div class="flex justify-end gap-2 mt-6">
+          <a-button @click="closeBusyManager">Hủy</a-button>
+          <a-button type="primary" @click="handleBusyOk" :loading="confirmLoading">Cập Nhật</a-button>
+        </div>
+      </div>
+    </a-modal>
   </div>
 </template>
 
 <script setup>
+import { h } from 'vue'
 const settingStore = useSettingStore();
 const { RestApi } = useApi();
 
 const busy_modal = ref(false);
+const busy_manager_modal = ref(false);
+const selectedClassroom = ref(null);
 const busy_data = ref();
 
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
@@ -144,6 +161,22 @@ const columns = [
   { title: 'Điểm trường', dataIndex: 'ten_diem_truong', key: 'ten_diem_truong' },
   { title: 'Bỏ kiểm tra xung đột', key: 'khong_kiem_tra_xung_dot', align: 'center' },
   { title: 'Thao tác', key: 'action', width: 120, align: 'center', fixed: 'right' }
+];
+
+const busyColumns = [
+  {
+    title: 'STT',
+    key: 'stt',
+    width: 60,
+    align: 'center',
+    customRender: ({ index }) => index + 1
+  },
+  {
+    title: 'Tên phòng học',
+    dataIndex: 'ten',
+    key: 'ten',
+    customRender: ({ record }) => h('a', { onClick: () => selectClassroom(record), class: 'text-blue-600 hover:underline' }, record.ten)
+  }
 ];
 
 const dataSource = ref([]);
@@ -199,6 +232,29 @@ const resetSearch = async () => {
   pagination.current = 1;
   param.value.search = '';
   await fetchData({ ...param.value });
+};
+
+const openBusyManager = async () => {
+  await fetchData({ ...param.value });
+  busy_manager_modal.value = true;
+};
+
+const closeBusyManager = () => {
+  busy_manager_modal.value = false;
+  selectedClassroom.value = null;
+  busy_data.value = null;
+};
+
+const selectClassroom = async (record) => {
+  selectedClassroom.value = record;
+  try {
+    const { data } = await RestApi.classroom.get_busy({ params: { id: record.id } });
+    if (data.value?.status === 'success') {
+      busy_data.value = data.value.data;
+    }
+  } catch {
+    message.error('Không thể tải dữ liệu phòng học');
+  }
 };
 
 const showModal = async () => {

--- a/pages/category_management/classroom.vue
+++ b/pages/category_management/classroom.vue
@@ -132,13 +132,6 @@
           <div class="flex justify-end gap-2 mt-auto pt-2">
             <a-button @click="closeBusyManager">Hủy</a-button>
             <a-button @click="saveBusy" :loading="confirmLoading">Lưu</a-button>
-            <a-button
-              type="primary"
-              @click="handleBusyOk"
-              :loading="confirmLoading"
-            >
-              Cập Nhật
-            </a-button>
           </div>
         </div>
       </div>
@@ -160,7 +153,7 @@ const busy_data = ref();
 
 const breakpoints = useBreakpoints(breakpointsTailwind);
 const isMobile = breakpoints.smaller('md');
-const busyModalWidth = computed(() => (isMobile.value ? '95vw' : 800));
+const busyModalWidth = computed(() => (isMobile.value ? '95vw' : 1000));
 
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 const searchText = ref('');

--- a/pages/category_management/classroom.vue
+++ b/pages/category_management/classroom.vue
@@ -104,16 +104,40 @@
         <a-button type="primary" @click="handleBusyOk" :loading="confirmLoading">Cập Nhật</a-button>
       </div>
     </a-modal>
-    <a-modal v-model:open="busy_manager_modal" title="Cài đặt tiết bận" @cancel="closeBusyManager" :width="800" :footer="null">
-      <a-table :columns="busyColumns" :data-source="dataSource" :pagination="false" bordered size="small" />
-      <div v-if="selectedClassroom && busy_data" class="mt-4">
-        <h3 class="font-medium mb-2">{{ selectedClassroom.ten }}</h3>
-        <div v-for="(block) in busy_data.ds_Ca" :key="block.id" style="margin-bottom: 2rem;">
-          <Timetable :block="block" />
-        </div>
-        <div class="flex justify-end gap-2 mt-6">
-          <a-button @click="closeBusyManager">Hủy</a-button>
-          <a-button type="primary" @click="handleBusyOk" :loading="confirmLoading">Cập Nhật</a-button>
+    <a-modal
+      v-model:open="busy_manager_modal"
+      title="Cài đặt tiết bận"
+      @cancel="closeBusyManager"
+      :width="busyModalWidth"
+      :footer="null"
+    >
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <a-table
+          :columns="busyColumns"
+          :data-source="dataSource"
+          :pagination="false"
+          bordered
+          size="small"
+        />
+        <div v-if="selectedClassroom && busy_data" class="flex flex-col">
+          <h3 class="font-medium mb-2">{{ selectedClassroom.ten }}</h3>
+          <div
+            v-for="(block) in busy_data.ds_Ca"
+            :key="block.id"
+            class="mb-8"
+          >
+            <Timetable :block="block" />
+          </div>
+          <div class="flex justify-end gap-2 mt-auto pt-2">
+            <a-button @click="closeBusyManager">Hủy</a-button>
+            <a-button
+              type="primary"
+              @click="handleBusyOk"
+              :loading="confirmLoading"
+            >
+              Cập Nhật
+            </a-button>
+          </div>
         </div>
       </div>
     </a-modal>
@@ -121,7 +145,8 @@
 </template>
 
 <script setup>
-import { h } from 'vue'
+import { h, computed } from 'vue'
+import { useBreakpoints, breakpointsTailwind } from '@vueuse/core'
 const settingStore = useSettingStore();
 const { RestApi } = useApi();
 
@@ -129,6 +154,10 @@ const busy_modal = ref(false);
 const busy_manager_modal = ref(false);
 const selectedClassroom = ref(null);
 const busy_data = ref();
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const isMobile = breakpoints.smaller('md');
+const busyModalWidth = computed(() => (isMobile.value ? '95vw' : 800));
 
 const param = ref({ PageIndex: 1, PageSize: 10, search: "" });
 const searchText = ref('');

--- a/pages/category_management/classroom.vue
+++ b/pages/category_management/classroom.vue
@@ -101,6 +101,7 @@
       </div>
       <div class="flex justify-end gap-2 mt-6">
         <a-button @click="handleBusyCancel">Hủy</a-button>
+        <a-button @click="saveBusy" :loading="confirmLoading">Lưu</a-button>
         <a-button type="primary" @click="handleBusyOk" :loading="confirmLoading">Cập Nhật</a-button>
       </div>
     </a-modal>
@@ -130,6 +131,7 @@
           </div>
           <div class="flex justify-end gap-2 mt-auto pt-2">
             <a-button @click="closeBusyManager">Hủy</a-button>
+            <a-button @click="saveBusy" :loading="confirmLoading">Lưu</a-button>
             <a-button
               type="primary"
               @click="handleBusyOk"
@@ -151,6 +153,7 @@ const settingStore = useSettingStore();
 const { RestApi } = useApi();
 
 const busy_modal = ref(false);
+// ===== Busy manager section start =====
 const busy_manager_modal = ref(false);
 const selectedClassroom = ref(null);
 const busy_data = ref();
@@ -192,6 +195,7 @@ const columns = [
   { title: 'Thao tác', key: 'action', width: 120, align: 'center', fixed: 'right' }
 ];
 
+// ===== Busy manager section start =====
 const busyColumns = [
   {
     title: 'STT',
@@ -206,6 +210,7 @@ const busyColumns = [
     key: 'ten',
     customRender: ({ record }) => h('a', { onClick: () => selectClassroom(record), class: 'text-blue-600 hover:underline' }, record.ten)
   }
+
 ];
 
 const dataSource = ref([]);
@@ -263,6 +268,7 @@ const resetSearch = async () => {
   await fetchData({ ...param.value });
 };
 
+// ===== Busy manager section start =====
 const openBusyManager = async () => {
   await fetchData({ ...param.value });
   busy_manager_modal.value = true;
@@ -350,23 +356,35 @@ const handleOk = async () => {
     confirmLoading.value = false;
   }
 };
-const handleBusyOk = async () => {
+// ===== Busy manager section start =====
+const updateBusy = async () => {
   try {
     confirmLoading.value = true;
     const { data, error } = await RestApi.classroom.update_busy({ body: busy_data.value });
     if (data.value?.status === 'success') {
-      message.success(data.value.message || 'Cập nhật thành công')
-      busy_modal.value = false
-    } else {
-      throw new Error(error.value?.data?.message || 'Cập nhật không thành công')
+      message.success(data.value.message || 'Cập nhật thành công');
+      return true;
     }
-  }
-  catch (error) {
-    message.error(error.message || error.response?.data?.message || 'Đã xảy ra lỗi khi lưu thông tin')
+    throw new Error(error.value?.data?.message || 'Cập nhật không thành công');
+  } catch (error) {
+    message.error(error.message || error.response?.data?.message || 'Đã xảy ra lỗi khi lưu thông tin');
+    return false;
   } finally {
     confirmLoading.value = false;
   }
-}
+};
+
+const handleBusyOk = async () => {
+  if (await updateBusy()) {
+    busy_modal.value = false;
+    busy_manager_modal.value = false;
+  }
+};
+
+const saveBusy = async () => {
+  await updateBusy();
+};
+// ===== Busy manager section end =====
 const handleCancel = () => {
   formRef.value?.resetFields();
   visible.value = false;


### PR DESCRIPTION
## Summary
- allow opening busy period manager
- show timetable after selecting a classroom

## Testing
- `yarn lint` *(fails: Request was cancelled due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_b_685386bbe64c8331b6377e67724fdfda