### PR TITLE
Implement subject page and select component

### DIFF
--- a/components/Select/Subject.vue
+++ b/components/Select/Subject.vue
@@ -1,0 +1,74 @@
+<template>
+  <a-form-item :label="label" :name="name" :rules="rules">
+    <a-select
+      :value="modelValue"
+      @update:value="val => $emit('update:modelValue', val)"
+      :mode="multiple ? 'multiple' : undefined"
+      show-search
+      :placeholder="placeholder"
+      :loading="loading"
+      :disabled="disabled"
+      allow-clear
+      class="w-full"
+      :options="options"
+      @search="onSearch"
+      :filter-option="false"
+    />
+  </a-form-item>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import debounce from 'lodash/debounce'
+
+const { RestApi } = useApi()
+
+const props = defineProps({
+  modelValue: [Array, Number, String],
+  label: { type: String, default: 'Môn học' },
+  name: { type: String, default: 'monhoc' },
+  multiple: { type: Boolean, default: false },
+  placeholder: { type: String, default: 'Chọn môn học' },
+  rules: { type: Array, default: () => [] },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const options = ref([])
+const loading = ref(false)
+
+const fetchSubject = async (search = '') => {
+  loading.value = true
+  try {
+    const { data } = await RestApi.subject.list({ params: { search } })
+    if (data.value?.data?.items) {
+      options.value = data.value.data.items.map(item => ({
+        label: item.ten,
+        value: item.id,
+      }))
+      if (
+        props.modelValue === null ||
+        props.modelValue === undefined
+      ) {
+        const first = options.value[0]
+        if (first) emit('update:modelValue', first.value)
+      }
+    }
+  } catch (error) {
+    console.error('❌ Lỗi fetch môn học:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+const debouncedFetch = debounce((val) => {
+  fetchSubject(val.trim())
+}, 300)
+
+const onSearch = (val) => {
+  debouncedFetch(val)
+}
+
+await fetchSubject()
+</script>

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -20,6 +20,9 @@ let ENDPOINTS = {
   CLASSROOM_TYPE_DETAIL: "/api/loaiphonghoc/detail",
   //KNOWLEDGE
   KNOWLEDGE: "/api/khoikienthuc",
+  //SUBJECT
+  SUBJECT: "/api/monhoc",
+  SUBJECT_DETAIL: "/api/monhoc/detail",
   //EXPERTISE
   EXPERTISE: "/api/tochuyenmon",
   //GRADE_LEVEL
@@ -134,6 +137,7 @@ class RestApi {
     this.knowledge = new Knowledge(this.request);
     this.expertise = new Expertise(this.request);
     this.grade_level = new GradeLevel(this.request);
+    this.subject = new Subject(this.request);
     this.roles = new Roles(this.request);
     this.classroom = new Classroom(this.request);
     this.school_day = new SchoolDay(this.request);
@@ -430,6 +434,26 @@ class Classroom {
   }
   async update_busy(data) {
     return await this.request.post(ENDPOINTS.CLASSROOM_BUSY, data);
+  }
+}
+class Subject {
+  constructor() {
+    this.request = new Request();
+  }
+  async list(data) {
+    return await this.request.get(ENDPOINTS.SUBJECT, data);
+  }
+  async detail(data) {
+    return await this.request.get(ENDPOINTS.SUBJECT_DETAIL, data);
+  }
+  async create(data) {
+    return await this.request.post(ENDPOINTS.SUBJECT, data);
+  }
+  async update(data) {
+    return await this.request.put(ENDPOINTS.SUBJECT, data);
+  }
+  async delete(data) {
+    return await this.request.delete(ENDPOINTS.SUBJECT, data);
   }
 }
 class SchoolDay {

--- a/pages/category_management/subject.vue
+++ b/pages/category_management/subject.vue
@@ -1,0 +1,278 @@
+<template>
+  <div class="p-2 md:p-4 bg-white min-h-full">
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
+      <a-input-search v-model:value="searchText" placeholder="Tìm kiếm môn học..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
+      <a-button @click="resetForm" class="w-full md:w-auto">
+        <span class="md:inline">Đặt lại</span>
+      </a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">
+        <span class="md:inline">Thêm mới</span>
+      </a-button>
+    </div>
+
+    <ClientOnly class="overflow-x-auto">
+      <a-table :columns="columns" :data-source="dataSource" :pagination="pagination" :loading="loading" :scroll="{ x: '1000' }" @change="handleTableChange" bordered size="small">
+        <template #bodyCell="{ column, record, index }">
+          <template v-if="column.key === 'stt'">
+            {{ (pagination.current - 1) * pagination.pageSize + index + 1 }}
+          </template>
+          <template v-if="column.key === 'bool'">
+            <span>{{ record[column.dataIndex] ? '✔️' : '❌' }}</span>
+          </template>
+          <template v-if="column.key === 'action'">
+            <div class="flex justify-center">
+              <div class="md:flex space-x-2">
+                <a-button type="link" size="small" @click="editItem(record)" :disabled="!settingStore.currentPermission">
+                  <template #icon>
+                    <EditOutlined />
+                  </template>
+                </a-button>
+                <a-popconfirm placement="topRight" title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
+                    <template #icon>
+                      <DeleteOutlined />
+                    </template>
+                  </a-button>
+                </a-popconfirm>
+              </div>
+            </div>
+          </template>
+        </template>
+      </a-table>
+    </ClientOnly>
+
+    <a-modal v-model:open="visible" :title="isEdit ? 'Chỉnh sửa môn học' : 'Thêm mới môn học'" @cancel="handleCancel" :width="700">
+      <a-form ref="formRef" :model="formState" layout="vertical" :rules="rules">
+        <a-form-item label="Tên môn học" name="ten">
+          <a-input v-model:value="formState.ten" placeholder="Nhập tên môn học" :maxlength="200" show-count />
+        </a-form-item>
+        <SelectClassroomType v-model="formState.Id_loai_phong_hoc" name="Id_loai_phong_hoc" :rules="rules.Id_loai_phong_hoc" />
+        <SelectKnowledge v-model="formState.Id_khoi_kien_thuc" name="Id_khoi_kien_thuc" />
+        <a-form-item>
+          <a-checkbox v-model:checked="formState.Do_GVCN_phu_trach">Do GVCN phụ trách</a-checkbox>
+        </a-form-item>
+        <a-form-item>
+          <a-checkbox v-model:checked="formState.Khong_can_phong_hoc">Không cần phòng học</a-checkbox>
+        </a-form-item>
+        <a-form-item>
+          <a-checkbox v-model:checked="formState.Hoc_cach_ngay">Học cách ngày</a-checkbox>
+        </a-form-item>
+        <a-form-item>
+          <a-checkbox v-model:checked="formState.Xep_thanh_cap">Xếp thành cặp</a-checkbox>
+        </a-form-item>
+        <a-form-item label="Số tiết tối đa một ca" name="So_tiet_toi_da_mot_ca">
+          <a-input-number v-model:value="formState.So_tiet_toi_da_mot_ca" :min="1" style="width: 100%" />
+        </a-form-item>
+        <a-form-item label="Số tiết tối đa hai ca" name="So_tiet_toi_da_hai_ca">
+          <a-input-number v-model:value="formState.So_tiet_toi_da_hai_ca" :min="1" style="width: 100%" />
+        </a-form-item>
+        <a-form-item>
+          <a-checkbox v-model:checked="formState.La_mon_tu_chon">Là môn tự chọn</a-checkbox>
+        </a-form-item>
+      </a-form>
+      <template #footer>
+        <div class="flex justify-end space-x-2">
+          <a-button @click="handleCancel">Hủy</a-button>
+          <a-button type="primary" @click="handleOk" :loading="confirmLoading">
+            {{ isEdit ? 'Cập nhật' : 'Thêm mới' }}
+          </a-button>
+        </div>
+      </template>
+    </a-modal>
+  </div>
+</template>
+
+<script setup>
+const settingStore = useSettingStore()
+const { RestApi } = useApi()
+
+const searchText = ref('')
+const loading = ref(false)
+const visible = ref(false)
+const confirmLoading = ref(false)
+const isEdit = ref(false)
+const formRef = ref()
+
+const pagination = reactive({
+  current: 1,
+  pageSize: 10,
+  total: 0,
+  showSizeChanger: true,
+  pageSizeOptions: ['1', '10', '20', '50'],
+  showTotal: total => `Tổng ${total} bản ghi`
+})
+
+const columns = [
+  { title: 'STT', key: 'stt', width: 50, align: 'center' },
+  { title: 'Tên môn học', dataIndex: 'ten', key: 'ten', ellipsis: true },
+  { title: 'Loại phòng học', dataIndex: 'ten_loai_phong_hoc', key: 'ten_loai_phong_hoc', ellipsis: true },
+  { title: 'Khối kiến thức', dataIndex: 'ten_khoi_kien_thuc', key: 'ten_khoi_kien_thuc', ellipsis: true },
+  { title: 'Số tiết/ca', dataIndex: 'so_tiet_toi_da_mot_ca', key: 'so_tiet_toi_da_mot_ca', align: 'center' },
+  { title: 'Số tiết/2 ca', dataIndex: 'so_tiet_toi_da_hai_ca', key: 'so_tiet_toi_da_hai_ca', align: 'center' },
+  { title: 'GVCN', dataIndex: 'do_GVCN_phu_trach', key: 'bool', align: 'center' },
+  { title: 'Tự chọn', dataIndex: 'la_mon_tu_chon', key: 'bool', align: 'center' },
+  { title: 'Thao tác', key: 'action', width: 80, align: 'center', fixed: 'right' }
+]
+
+const param = ref({ PageIndex: 1, PageSize: 10, search: '' })
+const dataSource = ref([])
+
+const formState = reactive({
+  ten: '',
+  Id_loai_phong_hoc: undefined,
+  Id_khoi_kien_thuc: undefined,
+  Do_GVCN_phu_trach: false,
+  Khong_can_phong_hoc: false,
+  Hoc_cach_ngay: false,
+  Xep_thanh_cap: false,
+  So_tiet_toi_da_mot_ca: 1,
+  So_tiet_toi_da_hai_ca: 2,
+  La_mon_tu_chon: false
+})
+
+const rules = reactive({
+  ten: [
+    { required: true, message: 'Vui lòng nhập tên môn học', trigger: 'blur' }
+  ],
+  Id_loai_phong_hoc: [
+    { required: true, message: 'Vui lòng chọn loại phòng học', trigger: 'blur' }
+  ],
+  So_tiet_toi_da_mot_ca: [
+    { required: true, message: 'Vui lòng nhập số tiết', trigger: 'blur', type: 'number' }
+  ],
+  So_tiet_toi_da_hai_ca: [
+    { required: true, message: 'Vui lòng nhập số tiết', trigger: 'blur', type: 'number' }
+  ]
+})
+
+const fetchData = async (param) => {
+  try {
+    loading.value = true
+    const { data } = await RestApi.subject.list({ params: param })
+    if (data.value?.status === 'success') {
+      dataSource.value = data.value.data.items || []
+      pagination.total = data.value.data.totalrecord
+    } else {
+      dataSource.value = []
+      pagination.total = 0
+    }
+  } catch (error) {
+    console.error('Error fetching data:', error)
+    message.error('Lỗi khi tải dữ liệu')
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleTableChange = async (pag) => {
+  pagination.current = pag.current
+  pagination.pageSize = pag.pageSize
+  param.value.PageIndex = pag.current
+  param.value.PageSize = pag.pageSize
+  await fetchData({ ...param.value })
+}
+
+const handleSearch = async () => {
+  param.value.search = searchText.value
+  pagination.current = 1
+  await fetchData({ ...param.value })
+}
+
+const showModal = () => {
+  isEdit.value = false
+  Object.assign(formState, {
+    ten: '',
+    Id_loai_phong_hoc: undefined,
+    Id_khoi_kien_thuc: undefined,
+    Do_GVCN_phu_trach: false,
+    Khong_can_phong_hoc: false,
+    Hoc_cach_ngay: false,
+    Xep_thanh_cap: false,
+    So_tiet_toi_da_mot_ca: 1,
+    So_tiet_toi_da_hai_ca: 2,
+    La_mon_tu_chon: false
+  })
+  visible.value = true
+}
+
+const editItem = async (record) => {
+  isEdit.value = true
+  try {
+    const { data } = await RestApi.subject.detail({ params: { Id: record.id } })
+    if (data.value?.status === 'success') {
+      Object.assign(formState, {
+        id: data.value.data.id,
+        ten: data.value.data.ten,
+        Id_loai_phong_hoc: data.value.data.id_loai_phong_hoc,
+        Id_khoi_kien_thuc: data.value.data.id_khoi_kien_thuc,
+        Do_GVCN_phu_trach: data.value.data.do_GVCN_phu_trach,
+        Khong_can_phong_hoc: data.value.data.khong_can_phong_hoc,
+        Hoc_cach_ngay: data.value.data.hoc_cach_ngay,
+        Xep_thanh_cap: data.value.data.xep_thanh_cap,
+        So_tiet_toi_da_mot_ca: data.value.data.so_tiet_toi_da_mot_ca,
+        So_tiet_toi_da_hai_ca: data.value.data.so_tiet_toi_da_hai_ca,
+        La_mon_tu_chon: data.value.data.la_mon_tu_chon
+      })
+      visible.value = true
+    }
+  } catch (err) {
+    message.error('Không thể lấy dữ liệu chi tiết')
+  }
+}
+
+const handleOk = async () => {
+  try {
+    await formRef.value.validate()
+    confirmLoading.value = true
+    const payload = { ...formState }
+    let res
+    if (isEdit.value) {
+      res = await RestApi.subject.update({ body: payload })
+    } else {
+      delete payload.id
+      res = await RestApi.subject.create({ body: payload })
+    }
+    if (res.data.value?.status === 'success') {
+      message.success(res.data.value?.message || 'Thành công')
+      await fetchData({ ...param.value })
+      visible.value = false
+      formRef.value.resetFields()
+    } else {
+      throw new Error(res.error?.value?.data?.message || 'Lỗi không xác định')
+    }
+  } catch (err) {
+    message.error(err.message || 'Lỗi khi lưu thông tin')
+  } finally {
+    confirmLoading.value = false
+  }
+}
+
+const handleCancel = () => {
+  formRef.value.resetFields()
+  visible.value = false
+}
+
+const deleteItem = async (id) => {
+  try {
+    const { data } = await RestApi.subject.delete({ params: { Id: id } })
+    if (data.value?.status === 'success') {
+      message.success(data.value?.message || 'Xóa thành công')
+      await fetchData({ ...param.value })
+    } else {
+      message.error(data.value?.message || 'Không thể xóa')
+    }
+  } catch (err) {
+    message.error('Lỗi khi xóa')
+  }
+}
+
+const resetForm = async () => {
+  if (formRef.value) formRef.value.resetFields()
+  param.value = { PageIndex: 1, PageSize: 10, search: '' }
+  pagination.current = 1
+  pagination.pageSize = 10
+  await fetchData({ ...param.value })
+}
+
+await fetchData({ ...param.value })
+</script>

--- a/pages/category_management/subject.vue
+++ b/pages/category_management/subject.vue
@@ -43,32 +43,36 @@
 
     <a-modal v-model:open="visible" :title="isEdit ? 'Chỉnh sửa môn học' : 'Thêm mới môn học'" @cancel="handleCancel" :width="700">
       <a-form ref="formRef" :model="formState" layout="vertical" :rules="rules">
-        <a-form-item label="Tên môn học" name="ten">
-          <a-input v-model:value="formState.ten" placeholder="Nhập tên môn học" :maxlength="200" show-count />
-        </a-form-item>
-        <SelectClassroomType v-model="formState.Id_loai_phong_hoc" name="Id_loai_phong_hoc" :rules="rules.Id_loai_phong_hoc" />
-        <SelectKnowledge v-model="formState.Id_khoi_kien_thuc" name="Id_khoi_kien_thuc" />
-        <a-form-item>
-          <a-checkbox v-model:checked="formState.Do_GVCN_phu_trach">Do GVCN phụ trách</a-checkbox>
-        </a-form-item>
-        <a-form-item>
-          <a-checkbox v-model:checked="formState.Khong_can_phong_hoc">Không cần phòng học</a-checkbox>
-        </a-form-item>
-        <a-form-item>
-          <a-checkbox v-model:checked="formState.Hoc_cach_ngay">Học cách ngày</a-checkbox>
-        </a-form-item>
-        <a-form-item>
-          <a-checkbox v-model:checked="formState.Xep_thanh_cap">Xếp thành cặp</a-checkbox>
-        </a-form-item>
-        <a-form-item label="Số tiết tối đa một ca" name="So_tiet_toi_da_mot_ca">
-          <a-input-number v-model:value="formState.So_tiet_toi_da_mot_ca" :min="1" style="width: 100%" />
-        </a-form-item>
-        <a-form-item label="Số tiết tối đa hai ca" name="So_tiet_toi_da_hai_ca">
-          <a-input-number v-model:value="formState.So_tiet_toi_da_hai_ca" :min="1" style="width: 100%" />
-        </a-form-item>
-        <a-form-item>
-          <a-checkbox v-model:checked="formState.La_mon_tu_chon">Là môn tự chọn</a-checkbox>
-        </a-form-item>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <a-form-item label="Tên môn học" name="ten">
+            <a-input v-model:value="formState.ten" placeholder="Nhập tên môn học" :maxlength="200" show-count />
+          </a-form-item>
+          <SelectClassroomType v-model="formState.Id_loai_phong_hoc" name="Id_loai_phong_hoc" :rules="rules.Id_loai_phong_hoc" />
+          <SelectKnowledge v-model="formState.Id_khoi_kien_thuc" name="Id_khoi_kien_thuc" />
+          <a-form-item label="Số tiết tối đa một ca" name="So_tiet_toi_da_mot_ca">
+            <a-input-number v-model:value="formState.So_tiet_toi_da_mot_ca" :min="1" style="width: 100%" />
+          </a-form-item>
+          <a-form-item label="Số tiết tối đa hai ca" name="So_tiet_toi_da_hai_ca">
+            <a-input-number v-model:value="formState.So_tiet_toi_da_hai_ca" :min="1" style="width: 100%" />
+          </a-form-item>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
+          <a-form-item>
+            <a-checkbox v-model:checked="formState.Do_GVCN_phu_trach">Do GVCN phụ trách</a-checkbox>
+          </a-form-item>
+          <a-form-item>
+            <a-checkbox v-model:checked="formState.Khong_can_phong_hoc">Không cần phòng học</a-checkbox>
+          </a-form-item>
+          <a-form-item>
+            <a-checkbox v-model:checked="formState.Hoc_cach_ngay">Học cách ngày</a-checkbox>
+          </a-form-item>
+          <a-form-item>
+            <a-checkbox v-model:checked="formState.Xep_thanh_cap">Xếp thành cặp</a-checkbox>
+          </a-form-item>
+          <a-form-item class="md:col-span-2">
+            <a-checkbox v-model:checked="formState.La_mon_tu_chon">Là môn tự chọn</a-checkbox>
+          </a-form-item>
+        </div>
       </a-form>
       <template #footer>
         <div class="flex justify-end space-x-2">

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -36,5 +36,8 @@
     <a-button type="primary" class="font-roboto w-full md:w-auto" @click="() => { navigateTo('/demo/role') }">
       Demo: SelectRole (Nhóm quyền)
     </a-button>
+    <a-button type="primary" class="font-roboto w-full md:w-auto" @click="() => { navigateTo('/demo/monhoc') }">
+      Demo: SelectSubject (Môn học)
+    </a-button>
   </div>
 </template>

--- a/pages/demo/monhoc.vue
+++ b/pages/demo/monhoc.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="max-w-3xl mx-auto p-6 space-y-6">
+    <h1 class="text-2xl font-bold">Demo: SelectSubject (Môn học)</h1>
+
+    <ClientOnly>
+      <a-form :model="form" @finish="submit" layout="vertical">
+        <SelectSubject
+          v-model="form.subjectMultiple"
+          label="Chọn nhiều môn học"
+          name="subjectMultiple"
+          :multiple="true"
+        />
+
+        <SelectSubject
+          v-model="form.subjectSingle"
+          label="Chọn một môn học"
+          name="subjectSingle"
+        />
+
+        <SelectSubject
+          v-model="form.subjectDisabled"
+          label="Môn học bị khóa"
+          name="subjectDisabled"
+          :disabled="true"
+        />
+
+        <a-button type="dashed" @click="modalOpen = true">Chọn môn học trong Modal</a-button>
+
+        <a-button html-type="submit" type="primary" class="mt-4">Gửi</a-button>
+      </a-form>
+
+      <a-modal v-model:open="modalOpen" title="Chọn môn học" @ok="submitModal">
+        <SelectSubject
+          v-model="modalForm.modalSubject"
+          label="Môn học modal"
+          name="modalSubject"
+        />
+      </a-modal>
+
+      <div class="mt-6">
+        <h2 class="font-semibold">📦 Form:</h2>
+        <pre class="bg-gray-100 p-4 rounded"><code>{{ form }}</code></pre>
+        <h2 class="font-semibold mt-2">🧪 Modal:</h2>
+        <pre class="bg-gray-100 p-4 rounded"><code>{{ modalForm }}</code></pre>
+      </div>
+
+      <div class="mt-10 border-t pt-6">
+        <h2 class="text-xl font-bold mb-4">📘 Hướng dẫn sử dụng & Props</h2>
+        <a-table :columns="columns" :data-source="propsTable" bordered size="small" row-key="prop" />
+      </div>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup>
+const form = reactive({
+  subjectMultiple: [1],
+  subjectSingle: null,
+  subjectDisabled: 1,
+})
+
+const modalForm = reactive({
+  modalSubject: null,
+})
+
+const modalOpen = ref(false)
+
+const submit = () => {
+  console.log('📤 Form:', form)
+}
+
+const submitModal = () => {
+  console.log('📤 Modal:', modalForm)
+  modalOpen.value = false
+}
+
+const columns = [
+  { title: 'Prop', dataIndex: 'prop' },
+  { title: 'Kiểu', dataIndex: 'type' },
+  { title: 'Mặc định', dataIndex: 'default' },
+  { title: 'Mô tả', dataIndex: 'desc' },
+]
+
+const propsTable = [
+  { prop: 'modelValue', type: 'Array | Number | String', default: '—', desc: 'Giá trị binding qua v-model' },
+  { prop: 'label', type: 'String', default: 'Môn học', desc: 'Nhãn hiển thị trên form item' },
+  { prop: 'name', type: 'String', default: 'monhoc', desc: 'Tên trường trong form' },
+  { prop: 'multiple', type: 'Boolean', default: 'false', desc: 'Cho phép chọn nhiều giá trị hay không' },
+  { prop: 'placeholder', type: 'String', default: 'Chọn môn học', desc: 'Placeholder hiển thị khi chưa chọn' },
+  { prop: 'rules', type: 'Array', default: '[]', desc: 'Mảng rule kiểm tra hợp lệ (validate)' },
+  { prop: 'disabled', type: 'Boolean', default: 'false', desc: 'Không cho người dùng tương tác nếu true' },
+]
+</script>


### PR DESCRIPTION
## Summary
- add SUBJECT endpoints and API class
- create `<SelectSubject>` component to pick subject options
- implement `/category_management/subject` page using list/create/detail APIs

## Testing
- `yarn build` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_6853eaffd7e8833182d1f04555b91097