### PR TITLE
Add teacher availability checks

### DIFF
--- a/pages/test/timetable.vue
+++ b/pages/test/timetable.vue
@@ -1,8 +1,17 @@
 <template>
   <div class="max-w-6xl mx-auto p-6 space-y-4">
     <h1 class="text-2xl font-bold mb-2">Demo xếp thời khóa biểu liên kết</h1>
+    <a-select v-model:value="timetableStore.currentClassId" class="mb-4 w-48">
+      <a-select-option
+        v-for="cls in timetableStore.classes"
+        :key="cls.id"
+        :value="cls.id"
+      >
+        {{ cls.name }}
+      </a-select-option>
+    </a-select>
     <div class="grid gap-6 md:grid-cols-1">
-      <ClassTimetable :timetable="timetable" />
+      <ClassTimetable :timetable="timetableStore.currentTimetable" />
     </div>
 
 
@@ -26,135 +35,14 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
+import { useTimetableStore } from '~/stores/timetableStore'
 
-const baseTimetable = {
-  ds_Ca: [
-    {
-      id: 1,
-      ds_Ngay: [
-        {
-          id: 1,
-          ten: 'Thứ 2',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: 'Anh', teacher: 'PT Thoản', teacherId: 2, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: 'Hóa', teacher: 'Cô Dung', teacherId: 5, isBreak: false },
-            { id: 3, ten: 'Tiết 3', subject: 'Văn', teacher: 'Cô Bình', teacherId: 1, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: 'Anh', teacher: 'PT Thoản', teacherId: 2, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: '', teacher: '', teacherId: null, isBreak: true }
-          ]
-        },
-        {
-          id: 2,
-          ten: 'Thứ 3',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false },
-            { id: 3, ten: 'Tiết 3', subject: '', teacher: '', teacherId: null, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: 'Lý', teacher: 'Thầy Cường', teacherId: 4, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false }
-          ]
-        },
-        {
-          id: 3,
-          ten: 'Thứ 4',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: 'Văn', teacher: 'Cô Bình', teacherId: 1, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: '', teacher: '', teacherId: null, isBreak: true },
-            { id: 3, ten: 'Tiết 3', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: 'Văn', teacher: 'Cô Bình', teacherId: 1, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: 'Hóa', teacher: 'Cô Dung', teacherId: 5, isBreak: false }
-          ]
-        },
-        {
-          id: 4,
-          ten: 'Thứ 5',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: 'Lý', teacher: 'Thầy Cường', teacherId: 4, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: 'Anh', teacher: 'PT Thoản', teacherId: 2, isBreak: false },
-            { id: 3, ten: 'Tiết 3', subject: 'Lý', teacher: 'Thầy Cường', teacherId: 4, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: '', teacher: '', teacherId: null, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: 'Anh', teacher: 'PT Thoản', teacherId: 2, isBreak: false }
-          ]
-        },
-        {
-          id: 5,
-          ten: 'Thứ 6',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: '', teacher: '', teacherId: null, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: 'Văn', teacher: 'Cô Bình', teacherId: 1, isBreak: false },
-            { id: 3, ten: 'Tiết 3', subject: '', teacher: '', teacherId: null, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: 'Lý', teacher: 'Thầy Cường', teacherId: 4, isBreak: false }
-          ]
-        }
-      ]
-    },
-    {
-      id: 2,
-      ds_Ngay: [
-        {
-          id: 1,
-          ten: 'Thứ 2',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: '', teacher: '', teacherId: null, isBreak: true },
-            { id: 2, ten: 'Tiết 2', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false },
-            { id: 3, ten: 'Tiết 3', subject: 'Văn', teacher: 'Cô Bình', teacherId: 1, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: '', teacher: '', teacherId: null, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: 'Hóa', teacher: 'Cô Dung', teacherId: 5, isBreak: false }
-          ]
-        },
-        {
-          id: 2,
-          ten: 'Thứ 3',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: 'Anh', teacher: 'PT Thoản', teacherId: 2, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: '', teacher: '', teacherId: null, isBreak: true },
-            { id: 3, ten: 'Tiết 3', subject: 'Lý', teacher: 'Thầy Cường', teacherId: 4, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: 'Lý', teacher: 'Thầy Cường', teacherId: 4, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: 'Văn', teacher: 'Cô Bình', teacherId: 1, isBreak: false }
-          ]
-        },
-        {
-          id: 3,
-          ten: 'Thứ 4',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: 'Hóa', teacher: 'Cô Dung', teacherId: 5, isBreak: false },
-            { id: 3, ten: 'Tiết 3', subject: '', teacher: '', teacherId: null, isBreak: true },
-            { id: 4, ten: 'Tiết 4', subject: 'Anh', teacher: 'PT Thoản', teacherId: 2, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false }
-          ]
-        },
-        {
-          id: 4,
-          ten: 'Thứ 5',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: 'Văn', teacher: 'Cô Bình', teacherId: 1, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: '', teacher: '', teacherId: null, isBreak: false },
-            { id: 3, ten: 'Tiết 3', subject: 'Toán', teacher: 'Thầy An', teacherId: 3, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: 'Văn', teacher: 'Cô Bình', teacherId: 1, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: 'Lý', teacher: 'Thầy Cường', teacherId: 4, isBreak: false }
-          ]
-        },
-        {
-          id: 5,
-          ten: 'Thứ 6',
-          ds_Tiet: [
-            { id: 1, ten: 'Tiết 1', subject: '', teacher: '', teacherId: null, isBreak: false },
-            { id: 2, ten: 'Tiết 2', subject: 'Anh', teacher: 'PT Thoản', teacherId: 2, isBreak: false },
-            { id: 3, ten: 'Tiết 3', subject: 'Hóa', teacher: 'Cô Dung', teacherId: 5, isBreak: false },
-            { id: 4, ten: 'Tiết 4', subject: 'Lý', teacher: 'Thầy Cường', teacherId: 4, isBreak: false },
-            { id: 5, ten: 'Tiết 5', subject: '', teacher: '', teacherId: null, isBreak: false }
-          ]
-        }
-      ]
-    }
-  ]
-}
+const timetableStore = useTimetableStore()
 
-const timetable = reactive(JSON.parse(JSON.stringify(baseTimetable)))
-
-const timetableJson = computed(() => JSON.stringify(timetable, null, 2))
+const timetableJson = computed(() =>
+  JSON.stringify(timetableStore.currentTimetable, null, 2)
+)
 </script>
 
 <style scoped>

--- a/stores/timetableStore.js
+++ b/stores/timetableStore.js
@@ -1,0 +1,85 @@
+import { defineStore } from 'pinia'
+
+const teachers = [
+  { id: 1, name: 'Cô Bình', subject: 'Văn' },
+  { id: 2, name: 'PT Thoản', subject: 'Anh' },
+  { id: 3, name: 'Thầy An', subject: 'Toán' },
+  { id: 4, name: 'Thầy Cường', subject: 'Lý' },
+  { id: 5, name: 'Cô Dung', subject: 'Hóa' }
+]
+
+const days = ['Thứ 2', 'Thứ 3', 'Thứ 4', 'Thứ 5', 'Thứ 6']
+const periods = [1, 2, 3, 4, 5]
+
+function generateTimetable(offset) {
+  const ds_Ca = [1, 2].map(caId => ({
+    id: caId,
+    ds_Ngay: days.map((day, dIndex) => ({
+      id: dIndex + 1,
+      ten: day,
+      ds_Tiet: periods.map(p => {
+        const teacher = teachers[(dIndex + p + offset - 1) % teachers.length]
+        return {
+          id: p,
+          ten: `Tiết ${p}`,
+          subject: teacher.subject,
+          teacher: teacher.name,
+          teacherId: teacher.id,
+          isBreak: false
+        }
+      })
+    }))
+  }))
+  return { ds_Ca }
+}
+
+function getTimetableForClass(index) {
+  return generateTimetable(index)
+}
+
+function findSlot(tt, caId, dayId, periodId) {
+  return tt.ds_Ca
+    .find(ca => ca.id === caId)?.ds_Ngay
+    .find(day => day.id === dayId)?.ds_Tiet
+    .find(tiet => tiet.id === periodId)
+}
+
+export const useTimetableStore = defineStore('timetable', {
+  state: () => ({
+    currentClassId: 1,
+    classes: [
+      { id: 1, name: 'Lớp 11A1', timetable: getTimetableForClass(0) },
+      { id: 2, name: 'Lớp 11A2', timetable: getTimetableForClass(1) },
+      { id: 3, name: 'Lớp 11A3', timetable: getTimetableForClass(2) }
+    ]
+  }),
+  getters: {
+    currentTimetable: state =>
+      state.classes.find(c => c.id === state.currentClassId)?.timetable
+  },
+  actions: {
+    setCurrentClass(id) {
+      this.currentClassId = id
+    },
+    isTeacherBusy(teacherId, caId, dayId, periodId, excludeClassId) {
+      return this.classes.some(cls => {
+        if (excludeClassId && cls.id === excludeClassId) return false
+        const slot = findSlot(cls.timetable, caId, dayId, periodId)
+        return slot && slot.teacherId === teacherId
+      })
+    },
+    assignLesson(classId, caId, dayId, periodId, teacher) {
+      if (this.isTeacherBusy(teacher.id, caId, dayId, periodId, classId))
+        return false
+      const cls = this.classes.find(c => c.id === classId)
+      if (!cls) return false
+      const slot = findSlot(cls.timetable, caId, dayId, periodId)
+      if (!slot) return false
+      slot.subject = teacher.subject
+      slot.teacher = teacher.name
+      slot.teacherId = teacher.id
+      slot.isBreak = false
+      return true
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- generate demo timetables for classes 11A1–11A3
- add helper methods to avoid assigning a teacher to multiple classes at the same time

## Testing
- `yarn build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870d276963c8326b6d84233708164e7