### PR TITLE
Improve timetable page guidance

### DIFF
--- a/components/ClassTimetable.vue
+++ b/components/ClassTimetable.vue
@@ -175,6 +175,12 @@ function getSlotInfo(row, col) {
   }
 }
 
+//
+// Kiểm tra điều kiện để có thể hoán đổi hai ô thời khóa biểu.
+//
+// Đây là nơi cần bổ sung các ràng buộc kéo thả bổ sung.
+// Ví dụ: hạn chế theo môn học, theo lớp hoặc bất kỳ quy tắc nào khác.
+// Trả về true nếu cho phép hoán đổi, ngược lại trả về false.
 function canSwap(srcRow, srcCol, dstRow, dstCol) {
   const src = getSlotInfo(srcRow, srcCol)
   const dst = getSlotInfo(dstRow, dstCol)
@@ -206,6 +212,7 @@ function canSwap(srcRow, srcCol, dstRow, dstCol) {
   return true
 }
 
+// Khi người dùng nhấp chuột để bắt đầu kéo
 function startHighlight(row, col) {
   const cell = getCell(row, col)
   if (cell.isBreak) return
@@ -213,6 +220,7 @@ function startHighlight(row, col) {
   dragSource.value = { row, col }
 }
 
+// Bắt đầu sự kiện kéo từ ô hợp lệ
 function onDragStart(row, col) {
   const cell = getCell(row, col)
   if (cell.isBreak) return
@@ -242,9 +250,11 @@ function isValidTarget(row, col) {
   const src = dragSource.value
   if (src.row === null) return false
   if (src.row === row && src.col === col) return false
+  // Kiểm tra xem điểm thả có thỏa mãn các điều kiện trong canSwap hay không
   return canSwap(src.row, src.col, row, col)
 }
 
+// Hiện menu chuột phải để thao tác với ô đang chọn
 function openMenu(event, row, col) {
   selected.value = { row, col }
   dragSource.value = { row, col }

--- a/pages/test/timetable.vue
+++ b/pages/test/timetable.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="max-w-6xl mx-auto p-6 space-y-4">
     <h1 class="text-2xl font-bold mb-2">Demo xếp thời khóa biểu liên kết</h1>
-    <a-select v-model:value="timetableStore.currentClassId" class="mb-4 w-48">
+    <!-- Lựa chọn lớp hiện tại -->
+    <a-select v-model:value="currentClassId" class="mb-4 w-48">
       <a-select-option
-        v-for="cls in timetableStore.classes"
+        v-for="cls in classes"
         :key="cls.id"
         :value="cls.id"
       >
@@ -23,6 +24,11 @@
         <li>Kéo thả các tiết để hoán đổi vị trí.</li>
         <li>Không thể kéo thả vào tiết nghỉ.</li>
         <li>Không thể đặt nghỉ ở ô đã có tiết học.</li>
+        <li>
+          Muốn thêm ràng buộc kéo thả hãy cập nhật hàm
+          <code>canSwap</code> trong
+          <code>components/ClassTimetable.vue</code>.
+        </li>
       </ul>
     </div>
 
@@ -36,12 +42,16 @@
 
 <script setup>
 import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useTimetableStore } from '~/stores/timetableStore'
 
 const timetableStore = useTimetableStore()
+// Trích xuất các giá trị phản ứng từ store để dễ sử dụng trong template
+const { currentClassId, classes, currentTimetable } = storeToRefs(timetableStore)
 
+// Chuỗi JSON hiển thị dữ liệu thời khóa biểu hiện tại
 const timetableJson = computed(() =>
-  JSON.stringify(timetableStore.currentTimetable, null, 2)
+  JSON.stringify(currentTimetable.value, null, 2)
 )
 </script>
 


### PR DESCRIPTION
## Summary
- refine `/test/timetable` page
- show how to add custom drag constraints in usage section
- extract reactive store values with `storeToRefs`
- document drag-n-drop constraint logic in `ClassTimetable.vue`

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68746a47bba0832687e0e6d981678e5b