### PR TITLE
Add timetable drag-and-drop demo

### DIFF
--- a/pages/demo/timetable-dnd.vue
+++ b/pages/demo/timetable-dnd.vue
@@ -1,0 +1,202 @@
+<template>
+  <div class="p-4 space-y-8">
+    <div v-for="klass in classes" :key="klass.id" class="space-y-4">
+      <h2 class="text-lg font-bold">{{ klass.name }}</h2>
+      <div v-for="(ca, caIndex) in klass.timetable.ds_Ca" :key="ca.id" class="space-y-2">
+        <h3 class="font-semibold">Ca {{ ca.id }}</h3>
+        <table class="min-w-full table-fixed border border-gray-200">
+          <thead>
+            <tr>
+              <th class="border p-2">Tiết / Ngày</th>
+              <th v-for="day in ca.ds_Ngay" :key="day.id" class="border p-2">
+                {{ day.ten }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(tiet, tIndex) in ca.ds_Ngay[0].ds_Tiet" :key="tiet.id">
+              <td class="border p-2 text-center">{{ tiet.ten }}</td>
+              <td v-for="(day, dIndex) in ca.ds_Ngay" :key="day.id"
+                  class="border p-2 text-center"
+                  :class="cellClass(klassIndex(klass), caIndex, dIndex, tIndex)"
+                  @dragstart="dragStart($event, klassIndex(klass), caIndex, dIndex, tIndex)"
+                  @dragover.prevent="dragOver($event, klassIndex(klass), caIndex, dIndex, tIndex)"
+                  @drop.prevent="drop($event, klassIndex(klass), caIndex, dIndex, tIndex)"
+                  :draggable="!day.ds_Tiet[tIndex].isBreak"
+              >
+                <span v-if="!day.ds_Tiet[tIndex].isBreak">{{ day.ds_Tiet[tIndex].subject }}</span>
+                <span v-else class="text-red-600">Nghỉ</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="mt-10 space-y-4">
+      <h2 class="text-lg font-bold">Bảng lịch giáo viên</h2>
+      <div v-for="teacher in teachers" :key="teacher.id" class="space-y-2">
+        <h3 class="font-semibold">{{ teacher.name }}</h3>
+        <div v-for="(ca, ci) in teacher.ds_Ca" :key="ci" class="space-y-1">
+          <h4 class="font-medium">Ca {{ ca.id }}</h4>
+          <table class="min-w-full table-fixed border border-gray-200 text-sm">
+            <thead>
+              <tr>
+                <th class="border p-1">Tiết / Ngày</th>
+                <th v-for="day in ca.ds_Ngay" :key="day.id" class="border p-1">{{ day.ten }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(tiet, ti) in ca.ds_Ngay[0].ds_Tiet" :key="ti">
+                <td class="border p-1 text-center">Tiết {{ ti + 1 }}</td>
+                <td v-for="(day, di) in ca.ds_Ngay" :key="di" class="border p-1 text-center">
+                  <span v-if="day.ds_Tiet[ti].className">
+                    {{ day.ds_Tiet[ti].className }} - {{ day.ds_Tiet[ti].subject }}
+                  </span>
+                  <span v-else>-</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref, onMounted } from 'vue'
+import timetableData from '~/public/data/timetable.json'
+
+const classes = reactive([])
+const teachers = reactive([])
+
+function klassIndex(klass) {
+  return classes.findIndex(k => k.id === klass.id)
+}
+
+const dragging = ref(null)
+const validCells = reactive(new Set())
+
+function dragStart(e, ki, ci, di, ti) {
+  dragging.value = { ki, ci, di, ti }
+  highlightValidCells()
+}
+
+function dragOver(e, ki, ci, di, ti) {
+  e.dataTransfer.dropEffect = validCells.has(key(ki, ci, di, ti)) ? 'move' : 'none'
+}
+
+function drop(e, ki, ci, di, ti) {
+  if (!dragging.value) return
+  const destKey = key(ki, ci, di, ti)
+  if (!validCells.has(destKey)) return
+  const src = getLesson(dragging.value)
+  const dest = getLesson({ ki, ci, di, ti })
+  ;[src.subject, dest.subject] = [dest.subject, src.subject]
+  ;[src.teacher, dest.teacher] = [dest.teacher, src.teacher]
+  ;[src.teacherId, dest.teacherId] = [dest.teacherId, src.teacherId]
+  dragging.value = null
+  validCells.clear()
+  teachers.splice(0, teachers.length, ...buildTeacherSchedules())
+}
+
+function key(ki, ci, di, ti) {
+  return `${ki}-${ci}-${di}-${ti}`
+}
+
+function getLesson({ ki, ci, di, ti }) {
+  return classes[ki].timetable.ds_Ca[ci].ds_Ngay[di].ds_Tiet[ti]
+}
+
+function highlightValidCells() {
+  validCells.clear()
+  if (!dragging.value) return
+  const lesson = getLesson(dragging.value)
+  for (let k = 0; k < classes.length; k++) {
+    for (let c = 0; c < classes[k].timetable.ds_Ca.length; c++) {
+      const days = classes[k].timetable.ds_Ca[c].ds_Ngay
+      for (let d = 0; d < days.length; d++) {
+        const periods = days[d].ds_Tiet
+        for (let t = 0; t < periods.length; t++) {
+          if (periods[t].isBreak) continue
+          const other = getLesson({ ki: k, ci: c, di: d, ti: t })
+          if (other.teacherId === lesson.teacherId && !(k === dragging.value.ki && c === dragging.value.ci && d === dragging.value.di && t === dragging.value.ti)) continue
+          let conflict = false
+          for (let ck = 0; ck < classes.length; ck++) {
+            const slot = classes[ck].timetable.ds_Ca[c].ds_Ngay[d].ds_Tiet[t]
+            if (slot.teacherId === lesson.teacherId && !(ck === dragging.value.ki && c === dragging.value.ci && d === dragging.value.di && t === dragging.value.ti)) {
+              conflict = true
+              break
+            }
+          }
+          if (!conflict) validCells.add(key(k, c, d, t))
+        }
+      }
+    }
+  }
+}
+
+function cellClass(ki, ci, di, ti) {
+  const base = []
+  const lesson = classes[ki].timetable.ds_Ca[ci].ds_Ngay[di].ds_Tiet[ti]
+  if (lesson.isBreak) base.push('bg-gray-100 text-red-600 border-black')
+  if (validCells.has(key(ki, ci, di, ti))) base.push('bg-green-50')
+  return base.join(' ')
+}
+
+onMounted(() => {
+  classes.push(...getData())
+  teachers.push(...buildTeacherSchedules())
+})
+
+function getData() {
+  return timetableData
+}
+
+function buildTeacherSchedules() {
+  const result = {}
+  const sampleCa = classes[0]?.timetable.ds_Ca[0]
+  const daysCount = sampleCa ? sampleCa.ds_Ngay.length : 0
+  const periodsCount = sampleCa ? sampleCa.ds_Ngay[0].ds_Tiet.length : 0
+  function initTeacher(id, name) {
+    const teacher = {
+      id,
+      name,
+      ds_Ca: [
+        { id: 1, ds_Ngay: [] },
+        { id: 2, ds_Ngay: [] }
+      ]
+    }
+    for (let c = 0; c < 2; c++) {
+      for (let d = 0; d < daysCount; d++) {
+        const day = { id: d + 1, ten: `Thứ ${d + 2}`, ds_Tiet: [] }
+        for (let t = 0; t < periodsCount; t++) {
+          day.ds_Tiet.push({ subject: '', className: '', isBreak: false })
+        }
+        teacher.ds_Ca[c].ds_Ngay.push(day)
+      }
+    }
+    result[id] = teacher
+  }
+
+  classes.forEach(klass => {
+    klass.timetable.ds_Ca.forEach((ca, ci) => {
+      ca.ds_Ngay.forEach((day, di) => {
+        day.ds_Tiet.forEach((tiet, ti) => {
+          if (!result[tiet.teacherId]) {
+            initTeacher(tiet.teacherId, tiet.teacher)
+          }
+          const target = result[tiet.teacherId].ds_Ca[ci].ds_Ngay[di].ds_Tiet[ti]
+          Object.assign(target, { subject: tiet.subject, className: klass.name, isBreak: tiet.isBreak })
+        })
+      })
+    })
+  })
+
+  return Object.values(result)
+}
+</script>
+
+<style scoped>
+</style>

--- a/public/data/timetable.json
+++ b/public/data/timetable.json
@@ -1,0 +1,1436 @@
+[
+  {
+    "id": 1,
+    "name": "Lớp 11A1",
+    "timetable": {
+      "ds_Ca": [
+        {
+          "id": 1,
+          "ds_Ngay": [
+            {
+              "id": 1,
+              "ten": "Thứ 2",
+              "ds_Tiet": [
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "ten": "Thứ 3",
+              "ds_Tiet": [
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "ten": "Thứ 4",
+              "ds_Tiet": [
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": true
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "ten": "Thứ 5",
+              "ds_Tiet": [
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 5,
+              "ten": "Thứ 6",
+              "ds_Tiet": [
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "ds_Ngay": [
+            {
+              "id": 1,
+              "ten": "Thứ 2",
+              "ds_Tiet": [
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "ten": "Thứ 3",
+              "ds_Tiet": [
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "ten": "Thứ 4",
+              "ds_Tiet": [
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": true
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "ten": "Thứ 5",
+              "ds_Tiet": [
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 5,
+              "ten": "Thứ 6",
+              "ds_Tiet": [
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "Cô Mai",
+                  "teacherId": 10,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "id": 2,
+    "name": "Lớp 11A2",
+    "timetable": {
+      "ds_Ca": [
+        {
+          "id": 1,
+          "ds_Ngay": [
+            {
+              "id": 1,
+              "ten": "Thứ 2",
+              "ds_Tiet": [
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "ten": "Thứ 3",
+              "ds_Tiet": [
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "ten": "Thứ 4",
+              "ds_Tiet": [
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": true
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "ten": "Thứ 5",
+              "ds_Tiet": [
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 5,
+              "ten": "Thứ 6",
+              "ds_Tiet": [
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "ds_Ngay": [
+            {
+              "id": 1,
+              "ten": "Thứ 2",
+              "ds_Tiet": [
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "ten": "Thứ 3",
+              "ds_Tiet": [
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "ten": "Thứ 4",
+              "ds_Tiet": [
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": true
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "ten": "Thứ 5",
+              "ds_Tiet": [
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 5,
+              "ten": "Thứ 6",
+              "ds_Tiet": [
+                {
+                  "subject": "Văn",
+                  "teacher": "Thầy Khánh",
+                  "teacherId": 6,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Cô Dung",
+                  "teacherId": 5,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "id": 3,
+    "name": "Lớp 11A3",
+    "timetable": {
+      "ds_Ca": [
+        {
+          "id": 1,
+          "ds_Ngay": [
+            {
+              "id": 1,
+              "ten": "Thứ 2",
+              "ds_Tiet": [
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "ten": "Thứ 3",
+              "ds_Tiet": [
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "ten": "Thứ 4",
+              "ds_Tiet": [
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": true
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "ten": "Thứ 5",
+              "ds_Tiet": [
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 5,
+              "ten": "Thứ 6",
+              "ds_Tiet": [
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "ds_Ngay": [
+            {
+              "id": 1,
+              "ten": "Thứ 2",
+              "ds_Tiet": [
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "ten": "Thứ 3",
+              "ds_Tiet": [
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "ten": "Thứ 4",
+              "ds_Tiet": [
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": true
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "ten": "Thứ 5",
+              "ds_Tiet": [
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            },
+            {
+              "id": 5,
+              "ten": "Thứ 6",
+              "ds_Tiet": [
+                {
+                  "subject": "Anh",
+                  "teacher": "PT Thoản",
+                  "teacherId": 2,
+                  "id": 1,
+                  "ten": "Tiết 1",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Toán",
+                  "teacher": "Thầy An",
+                  "teacherId": 3,
+                  "id": 2,
+                  "ten": "Tiết 2",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Lý",
+                  "teacher": "Thầy Dũng",
+                  "teacherId": 8,
+                  "id": 3,
+                  "ten": "Tiết 3",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Hóa",
+                  "teacher": "Thầy Tài",
+                  "teacherId": 9,
+                  "id": 4,
+                  "ten": "Tiết 4",
+                  "isBreak": false
+                },
+                {
+                  "subject": "Văn",
+                  "teacher": "Cô Bình",
+                  "teacherId": 1,
+                  "id": 5,
+                  "ten": "Tiết 5",
+                  "isBreak": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add timetable JSON dataset
- create `timetable-dnd.vue` demo page
- implement drag-and-drop timetable with teacher conflict checking and break periods
- show teacher timetable overview that updates when lessons move

## Testing
- `yarn install`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68748d9a3c40832687239398a02d0587