### PR TITLE
Add mobile drag support

### DIFF
--- a/components/ClassTimetable.vue
+++ b/components/ClassTimetable.vue
@@ -40,6 +40,11 @@
                 @contextmenu.prevent="openMenu($event, ki, caIndex, dIndex, tIndex)"
                 @click="day.ds_Tiet[tIndex].teacherId && selectTeacherLesson(day.ds_Tiet[tIndex].teacherId)"
                 :draggable="!day.ds_Tiet[tIndex].isBreak"
+                :data-ki="ki"
+                :data-ci="caIndex"
+                :data-di="dIndex"
+                :data-ti="tIndex"
+                @touchstart.prevent="touchStart($event, ki, caIndex, dIndex, tIndex)"
               >
                 <template v-if="!day.ds_Tiet[tIndex].isBreak">
                   <div class="line-clamp-1">{{ day.ds_Tiet[tIndex].subject }}</div>
@@ -98,6 +103,7 @@ const classData = computed(() => props.klass)
 const {
   selectTeacherLesson,
   dragStart,
+  touchStart,
   dragEnter,
   dragOver,
   drop,

--- a/composables/useTimetableDnD.js
+++ b/composables/useTimetableDnD.js
@@ -70,6 +70,54 @@ export const useTimetableDnD = () => {
     highlightValidCells()
   }
 
+  let touchMoveHandler
+  let touchEndHandler
+
+  function touchStart(e, ki, ci, di, ti) {
+    dragStart(e, ki, ci, di, ti)
+    touchMoveHandler = evt => touchMove(evt)
+    touchEndHandler = evt => touchEnd(evt)
+    document.addEventListener('touchmove', touchMoveHandler, { passive: false })
+    document.addEventListener('touchend', touchEndHandler)
+  }
+
+  function touchMove(e) {
+    const touch = e.touches[0]
+    if (!touch) return
+    const el = document.elementFromPoint(touch.clientX, touch.clientY)
+    const cell = el && el.closest('td[data-ki]')
+    if (cell) {
+      const ki = Number(cell.dataset.ki)
+      const ci = Number(cell.dataset.ci)
+      const di = Number(cell.dataset.di)
+      const ti = Number(cell.dataset.ti)
+      dragEnter(e, ki, ci, di, ti)
+      dragOver(e, ki, ci, di, ti)
+    }
+    e.preventDefault()
+  }
+
+  function touchEnd(e) {
+    document.removeEventListener('touchmove', touchMoveHandler)
+    document.removeEventListener('touchend', touchEndHandler)
+    const touch = e.changedTouches[0]
+    if (!touch) {
+      dragEnd()
+      return
+    }
+    const el = document.elementFromPoint(touch.clientX, touch.clientY)
+    const cell = el && el.closest('td[data-ki]')
+    if (cell) {
+      const ki = Number(cell.dataset.ki)
+      const ci = Number(cell.dataset.ci)
+      const di = Number(cell.dataset.di)
+      const ti = Number(cell.dataset.ti)
+      drop(e, ki, ci, di, ti)
+    } else {
+      dragEnd()
+    }
+  }
+
   function dragOver(e, ki, ci, di, ti) {
     e.dataTransfer.dropEffect = validCells.has(key(ki, ci, di, ti)) ? 'move' : 'none'
   }
@@ -356,6 +404,9 @@ export const useTimetableDnD = () => {
     selectTeacherLesson,
     teacherCellClick,
     dragStart,
+    touchStart,
+    touchMove,
+    touchEnd,
     dragEnter,
     dragOver,
     drop,


### PR DESCRIPTION
## Summary
- enable drag-and-drop on mobile for `ClassTimetable` by adding touch handlers
- implement `touchStart`, `touchMove`, and `touchEnd` in drag-and-drop composable

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_687782e20058832687032430f95a839c