### PR TITLE
Fix context menu positioning

### DIFF
--- a/components/ClassTimetable.vue
+++ b/components/ClassTimetable.vue
@@ -60,7 +60,7 @@
     <div
       v-if="contextMenu.visible"
       :style="contextMenu.style"
-      class="absolute bg-white border border-gray-200 rounded-md shadow-lg z-50 text-sm"
+      class="fixed bg-white border border-gray-200 rounded-md shadow-lg z-50 text-sm"
     >
       <ul>
         <li class="px-4 py-2 hover:bg-gray-50 cursor-pointer" @click.stop="removeLesson()">Xóa tiết học</li>

--- a/pages/demo/timetable-dnd.vue
+++ b/pages/demo/timetable-dnd.vue
@@ -70,7 +70,7 @@
         </div>
       </div>
     </div>
-    <div v-if="contextMenu.visible" :style="contextMenu.style" class="absolute bg-white border rounded shadow z-50 text-sm">
+    <div v-if="contextMenu.visible" :style="contextMenu.style" class="fixed bg-white border rounded shadow z-50 text-sm">
       <ul>
         <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click.stop="removeLesson()">Xóa tiết học</li>
         <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click.stop="toggleBreak()">


### PR DESCRIPTION
## Summary
- use `fixed` positioning for the timetable drag-and-drop context menu

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68785b4ed9b08326bb08ddf8451e20a4