### PR TITLE
Add schoolship management page

### DIFF
--- a/components/Select/Schoolship.vue
+++ b/components/Select/Schoolship.vue
@@ -1,0 +1,70 @@
+<template>
+  <a-form-item :label="label" :name="name" :rules="rules">
+    <a-select
+      :value="modelValue"
+      @update:value="val => $emit('update:modelValue', val)"
+      :mode="multiple ? 'multiple' : undefined"
+      show-search
+      :placeholder="placeholder"
+      :loading="loading"
+      :disabled="disabled"
+      allow-clear
+      class="w-full"
+      :options="options"
+      @search="onSearch"
+      :filter-option="false"
+    />
+  </a-form-item>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import debounce from 'lodash/debounce'
+
+const { RestApi } = useApi()
+
+const props = defineProps({
+  modelValue: [Array, Number, String],
+  label: { type: String, default: 'Ban học' },
+  name: { type: String, default: 'banhoc' },
+  multiple: { type: Boolean, default: false },
+  placeholder: { type: String, default: 'Chọn ban học' },
+  rules: { type: Array, default: () => [] },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const options = ref([])
+const loading = ref(false)
+
+const fetchData = async (search = '') => {
+  loading.value = true
+  try {
+    const { data } = await RestApi.school_ship.list({ params: { search } })
+    if (data.value?.data?.items) {
+      options.value = data.value.data.items.map(item => ({
+        label: item.ten,
+        value: item.id,
+      }))
+      if (props.modelValue === undefined || props.modelValue === null || props.modelValue === '') {
+        emit('update:modelValue', props.modelValue)
+      }
+    }
+  } catch (error) {
+    console.error('❌ Lỗi fetch ban học:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+const debouncedFetch = debounce((val) => {
+  fetchData(val.trim())
+}, 300)
+
+const onSearch = (val) => {
+  debouncedFetch(val)
+}
+
+await fetchData()
+</script>

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -46,6 +46,9 @@ let ENDPOINTS = {
   //SCHOOL_DAY
   SCHOOL_DAY: "/api/ngayhoc",
   SCHOOL_DAY_DETAIL: "/api/ngayhoc/detail",
+  //SCHOOL_SHIP
+  SCHOOL_SHIP: "/api/banhoc",
+  SCHOOL_SHIP_DETAIL: "/api/banhoc/detail",
   //FIXED_LESSON
   FIXED_LESSON: "/api/tietcodinh",
   FIXED_LESSON_DETAIL: "/api/tietcodinh/detail",
@@ -135,6 +138,7 @@ class RestApi {
     this.user = new User(this.request);
     this.school_level = new SchoolLevel(this.request);
     this.school_shift = new SchoolShift(this.request);
+    this.school_ship = new SchoolShip(this.request);
     this.unit = new Unit(this.request);
     this.school_site = new SchoolSite(this.request);
     this.classroom_type = new ClassroomType(this.request);
@@ -257,6 +261,27 @@ class SchoolShift {
   }
   async delete(data) {
     return await this.request.delete(ENDPOINTS.SCHOOL_SHIFT, data);
+  }
+}
+
+class SchoolShip {
+  constructor() {
+    this.request = new Request();
+  }
+  async list(data) {
+    return await this.request.get(ENDPOINTS.SCHOOL_SHIP, data);
+  }
+  async detail(data) {
+    return await this.request.get(ENDPOINTS.SCHOOL_SHIP_DETAIL, data);
+  }
+  async create(data) {
+    return await this.request.post(ENDPOINTS.SCHOOL_SHIP, data);
+  }
+  async update(data) {
+    return await this.request.put(ENDPOINTS.SCHOOL_SHIP, data);
+  }
+  async delete(data) {
+    return await this.request.delete(ENDPOINTS.SCHOOL_SHIP, data);
   }
 }
 class Unit {

--- a/pages/category_management/schoolship.vue
+++ b/pages/category_management/schoolship.vue
@@ -1,0 +1,215 @@
+<template>
+  <div class="p-2 md:p-4 bg-white min-h-full">
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-4">
+      <a-input-search v-model:value="searchText" placeholder="Tìm kiếm ban học..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
+      <a-button @click="resetForm" class="w-full md:w-auto">Đặt lại</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
+    </div>
+
+    <ClientOnly class="overflow-x-auto">
+      <a-table :columns="columns" :data-source="dataSource" :pagination="pagination" :loading="loading" :scroll="{ x: '800' }" @change="handleTableChange" bordered size="small">
+        <template #bodyCell="{ column, record, index }">
+          <template v-if="column.key === 'stt'">
+            {{ (pagination.current - 1) * pagination.pageSize + index + 1 }}
+          </template>
+          <template v-if="column.key === 'ghi_chu'">
+            <span v-if="record.ghi_chu">{{ record.ghi_chu }}</span>
+            <span v-else class="text-gray-400">Trống</span>
+          </template>
+          <template v-if="column.key === 'action'">
+            <div class="flex justify-center">
+              <div class="md:flex space-x-2">
+                <a-button type="link" size="small" @click="editItem(record.id)" :disabled="!settingStore.currentPermission">
+                  <template #icon>
+                    <EditOutlined />
+                  </template>
+                </a-button>
+                <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
+                  <a-button type="link" danger size="small" :disabled="!settingStore.currentPermission">
+                    <template #icon>
+                      <DeleteOutlined />
+                    </template>
+                  </a-button>
+                </a-popconfirm>
+              </div>
+            </div>
+          </template>
+        </template>
+      </a-table>
+    </ClientOnly>
+
+    <a-modal v-model:open="visible" :title="isEdit ? 'Chỉnh sửa ban học' : 'Thêm mới ban học'" @cancel="handleCancel" :width="600">
+      <a-form ref="formRef" :model="formState" layout="vertical">
+        <a-form-item label="Tên ban học" name="ten" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }" :rules="rules.ten">
+          <a-input v-model:value="formState.ten" placeholder="Nhập tên ban học" :maxlength="200" show-count />
+        </a-form-item>
+        <SelectSchoolLevel v-model="formState.id_cap_hoc" name="id_cap_hoc" :rules="rules.id_cap_hoc" />
+        <a-form-item label="Ghi chú" name="ghichu" :label-col="{ span: 24 }" :wrapper-col="{ span: 24 }">
+          <a-textarea v-model:value="formState.ghichu" :rows="4" placeholder="Nhập ghi chú (nếu có)" :maxlength="200" show-count />
+        </a-form-item>
+      </a-form>
+
+      <template #footer>
+        <div class="flex justify-end space-x-2">
+          <a-button @click="handleCancel">Hủy</a-button>
+          <a-button type="primary" @click="handleOk" :loading="confirmLoading">
+            {{ isEdit ? 'Cập nhật' : 'Thêm mới' }}
+          </a-button>
+        </div>
+      </template>
+    </a-modal>
+  </div>
+</template>
+
+<script setup>
+const settingStore = useSettingStore();
+const { RestApi } = useApi();
+
+const searchText = ref('');
+const loading = ref(false);
+const visible = ref(false);
+const confirmLoading = ref(false);
+const isEdit = ref(false);
+const formRef = ref();
+
+const pagination = reactive({
+  current: 1,
+  pageSize: 10,
+  total: 0,
+  showSizeChanger: true,
+  pageSizeOptions: ['1', '10', '20', '50'],
+  showTotal: (total) => `Tổng ${total} bản ghi`
+});
+
+const columns = [
+  { title: 'STT', key: 'stt', width: 50, align: 'center' },
+  { title: 'Tên ban học', dataIndex: 'ten', key: 'ten', ellipsis: true },
+  { title: 'Tên cấp học', dataIndex: 'ten_cap', key: 'ten_cap', ellipsis: true },
+  { title: 'Ghi chú', dataIndex: 'ghi_chu', key: 'ghi_chu', ellipsis: true },
+  { title: 'Thao tác', key: 'action', width: 80, align: 'center', fixed: 'right' }
+];
+
+const formState = reactive({
+  id: null,
+  ten: '',
+  ghichu: '',
+  id_cap_hoc: undefined
+});
+
+const rules = reactive({
+  ten: [
+    { required: true, message: 'Vui lòng nhập tên ban học', trigger: 'blur' },
+    { min: 2, message: 'Tên phải có ít nhất 2 ký tự', trigger: 'blur' }
+  ],
+  id_cap_hoc: [
+    { required: true, message: 'Vui lòng chọn cấp học', trigger: 'blur' }
+  ]
+});
+
+const param = ref({ PageIndex: 1, PageSize: 10, search: '' });
+const dataSource = ref([]);
+
+const fetchData = async (param) => {
+  try {
+    loading.value = true;
+    const { data } = await RestApi.school_ship.list({ params: param });
+    if (data.value?.status === 'success') {
+      dataSource.value = data.value.data.items || [];
+      pagination.total = data.value.data.totalrecord;
+    }
+  } catch (err) {
+    message.error('Không thể tải dữ liệu');
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleTableChange = async (pag) => {
+  pagination.current = pag.current;
+  pagination.pageSize = pag.pageSize;
+  param.value.PageIndex = pag.current;
+  param.value.PageSize = pag.pageSize;
+  await fetchData({ ...param.value });
+};
+
+const handleSearch = async () => {
+  param.value.search = searchText.value;
+  pagination.current = 1;
+  await fetchData({ ...param.value });
+};
+
+const showModal = async () => {
+  isEdit.value = false;
+  Object.assign(formState, { id: null, ten: '', ghichu: '', id_cap_hoc: undefined });
+  visible.value = true;
+};
+
+const editItem = async (id) => {
+  isEdit.value = true;
+  try {
+    const { data } = await RestApi.school_ship.detail({ params: { id } });
+    if (data.value?.status === 'success') {
+      Object.assign(formState, { ...data.value.data });
+      visible.value = true;
+    }
+  } catch (err) {
+    message.error('Không thể lấy dữ liệu chi tiết');
+  }
+};
+
+const handleOk = async () => {
+  try {
+    await formRef.value.validate();
+    confirmLoading.value = true;
+    const payload = { ...formState };
+    let res;
+    if (isEdit.value) {
+      res = await RestApi.school_ship.update({ body: payload });
+    } else {
+      delete payload.id;
+      res = await RestApi.school_ship.create({ body: payload });
+    }
+    if (res.data.value?.status === 'success') {
+      message.success(res.data.value?.message || 'Thành công');
+      await fetchData({ ...param.value });
+      visible.value = false;
+      formRef.value.resetFields();
+    } else {
+      throw new Error(res.error?.value?.data?.message || 'Lỗi không xác định');
+    }
+  } catch (err) {
+    message.error(err.message || 'Lỗi khi lưu thông tin');
+  } finally {
+    confirmLoading.value = false;
+  }
+};
+
+const handleCancel = () => {
+  formRef.value.resetFields();
+  visible.value = false;
+};
+
+const deleteItem = async (id) => {
+  try {
+    const { data } = await RestApi.school_ship.delete({ params: { id } });
+    if (data.value?.status === 'success') {
+      message.success(data.value?.message || 'Đã xóa');
+      await fetchData({ ...param.value });
+    } else {
+      message.error(data.value?.message || 'Không thể xóa');
+    }
+  } catch (err) {
+    message.error('Lỗi khi xóa');
+  }
+};
+
+const resetForm = async () => {
+  if (formRef.value) formRef.value.resetFields();
+  param.value = { PageIndex: 1, PageSize: 10, search: '' };
+  pagination.current = 1;
+  pagination.pageSize = 10;
+  await fetchData({ ...param.value });
+};
+
+await fetchData({ ...param.value });
+</script>

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -93,6 +93,17 @@
       class="font-roboto w-full md:w-auto"
       @click="
         () => {
+          navigateTo('/demo/banhoc');
+        }
+      "
+    >
+      Demo: SelectSchoolship (Ban học)
+    </a-button>
+    <a-button
+      type="primary"
+      class="font-roboto w-full md:w-auto"
+      @click="
+        () => {
           navigateTo('/demo/nguoidung');
         }
       "

--- a/pages/demo/banhoc.vue
+++ b/pages/demo/banhoc.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="max-w-3xl mx-auto p-6 space-y-6">
+    <h1 class="text-2xl font-bold">Demo: SelectSchoolship (Ban học)</h1>
+
+    <ClientOnly>
+      <a-form :model="form" @finish="submit" layout="vertical">
+        <SelectSchoolship
+          v-model="form.shipMultiple"
+          label="Chọn nhiều ban học"
+          name="shipMultiple"
+          :multiple="true"
+        />
+
+        <SelectSchoolship
+          v-model="form.shipSingle"
+          label="Chọn một ban học"
+          name="shipSingle"
+        />
+
+        <SelectSchoolship
+          v-model="form.shipDisabled"
+          label="Ban học bị khóa"
+          name="shipDisabled"
+          :disabled="true"
+        />
+
+        <a-button type="dashed" @click="modalOpen = true">Chọn ban học trong Modal</a-button>
+
+        <a-button html-type="submit" type="primary" class="mt-4">Gửi</a-button>
+      </a-form>
+
+      <a-modal v-model:open="modalOpen" title="Chọn ban học" @ok="submitModal">
+        <SelectSchoolship
+          v-model="modalForm.modalShip"
+          label="Ban học modal"
+          name="modalShip"
+        />
+      </a-modal>
+
+      <div class="mt-6">
+        <h2 class="font-semibold">📦 Form:</h2>
+        <pre class="bg-gray-100 p-4 rounded"><code>{{ form }}</code></pre>
+        <h2 class="font-semibold mt-2">🧪 Modal:</h2>
+        <pre class="bg-gray-100 p-4 rounded"><code>{{ modalForm }}</code></pre>
+      </div>
+
+      <div class="mt-10 border-t pt-6">
+        <h2 class="text-xl font-bold mb-4">📘 Hướng dẫn sử dụng & Props</h2>
+        <a-table :columns="columns" :data-source="propsTable" bordered size="small" row-key="prop" />
+      </div>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup>
+const form = reactive({
+  shipMultiple: [],
+  shipSingle: null,
+  shipDisabled: 1,
+})
+
+const modalForm = reactive({
+  modalShip: null,
+})
+
+const modalOpen = ref(false)
+
+const submit = () => {
+  console.log('📤 Form:', form)
+}
+
+const submitModal = () => {
+  console.log('📤 Modal:', modalForm)
+  modalOpen.value = false
+}
+
+const columns = [
+  { title: 'Prop', dataIndex: 'prop' },
+  { title: 'Kiểu', dataIndex: 'type' },
+  { title: 'Mặc định', dataIndex: 'default' },
+  { title: 'Mô tả', dataIndex: 'desc' },
+]
+
+const propsTable = [
+  { prop: 'modelValue', type: 'Array | Number | String', default: '—', desc: 'Giá trị binding qua v-model' },
+  { prop: 'label', type: 'String', default: 'Ban học', desc: 'Nhãn hiển thị trên form item' },
+  { prop: 'name', type: 'String', default: 'banhoc', desc: 'Tên trường trong form' },
+  { prop: 'multiple', type: 'Boolean', default: 'false', desc: 'Cho phép chọn nhiều giá trị hay không' },
+  { prop: 'placeholder', type: 'String', default: 'Chọn ban học', desc: 'Placeholder hiển thị' },
+  { prop: 'rules', type: 'Array', default: '[]', desc: 'Mảng rule kiểm tra hợp lệ (validate)' },
+  { prop: 'disabled', type: 'Boolean', default: 'false', desc: 'Không cho người dùng tương tác nếu true' },
+]
+</script>

--- a/pages/test/2.vue
+++ b/pages/test/2.vue
@@ -36,7 +36,7 @@
       <h2 class="text-lg font-semibold text-gray-700 mb-3">LỌC THÔNG TIN</h2>
       <a-form :model="filters" layout="vertical" :rules="rules" class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <SelectGradeLevel v-model="filters.grade" name="grade" :rules="rules.grade" placeholder="Chọn khối lớp" />
-        <SelectExpertise v-model="filters.major" name="major" :rules="rules.major" placeholder="Chọn ban học" />
+        <SelectSchoolship v-model="filters.major" name="major" :rules="rules.major" placeholder="Chọn ban học" />
         <SelectSchoolShift v-model="filters.shift" name="shift" :rules="rules.shift" placeholder="Chọn ca học" />
       </a-form>
     </div>


### PR DESCRIPTION
## Summary
- add `school_ship` endpoint support in `useApi`
- create Schoolship select component
- implement schoolship CRUD page

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_68820f2981548326a7270ca3a5193ea0