### PR TITLE
Add teacher scheduling avoid component

### DIFF
--- a/components/TeacherAvoid.vue
+++ b/components/TeacherAvoid.vue
@@ -1,16 +1,7 @@
 <template>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <a-card title="DANH SÁCH GIÁO VIÊN" class="md:col-span-1">
-      <a-table
-        :columns="columns"
-        :data-source="teachers"
-        :loading="loading"
-        :pagination="pagination"
-        size="small"
-        row-key="id"
-        @change="handleTableChange"
-        @rowClick="selectTeacher"
-      >
+      <a-table :columns="columns" :data-source="teachers" :loading="loading" :pagination="pagination" size="small" row-key="id" @change="handleTableChange" :customRow="onRow">
         <template #bodyCell="{ column, record, index }">
           <template v-if="column.key === 'stt'">
             {{ (pagination.current - 1) * pagination.pageSize + index + 1 }}
@@ -18,9 +9,7 @@
           <template v-if="column.key === 'code'">
             {{ record.ma_giao_vien }}
           </template>
-          <template v-if="column.key === 'name'">
-            {{ record.ho_va_ho_dem }} {{ record.ten }}
-          </template>
+          <template v-if="column.key === 'name'"> {{ record.ho_va_ho_dem }} {{ record.ten }} </template>
         </template>
       </a-table>
     </a-card>
@@ -46,58 +35,57 @@
 </template>
 
 <script setup>
-import { ref, reactive, onMounted } from 'vue'
-import { message } from 'ant-design-vue'
-import Timetable from './Timetable.vue'
-const { RestApi } = useApi()
+const { RestApi } = useApi();
 
-const teachers = ref([])
-const loading = ref(false)
-const selectedId = ref(null)
-const schedule = ref()
-const onlyOneShift = ref(false)
-const maxPeriod = ref(10)
-const saving = ref(false)
+const teachers = ref([]);
+const loading = ref(false);
+const selectedId = ref(null);
+const schedule = ref();
+const onlyOneShift = ref(false);
+const maxPeriod = ref(10);
+const saving = ref(false);
 
 const columns = [
-  { title: 'STT', key: 'stt', width: 60, align: 'center' },
-  { title: 'Mã giáo viên', key: 'code' },
-  { title: 'Họ và tên', key: 'name' }
-]
+  { title: "STT", key: "stt", width: 60, align: "center" },
+  { title: "Mã giáo viên", key: "code" },
+  { title: "Họ và tên", key: "name" },
+];
 
 const pagination = reactive({
   current: 1,
   pageSize: 10,
   total: 0,
   showSizeChanger: true,
-  pageSizeOptions: ['10', '20', '50'],
-  showTotal: total => `Tổng ${total} bản ghi`
-})
+  pageSizeOptions: ["10", "20", "50"],
+  showTotal: total => `Tổng ${total} bản ghi`,
+});
 
 async function fetchTeachers() {
   try {
-    loading.value = true
+    loading.value = true;
     const { data } = await RestApi.teacher.list({
       params: {
         PageIndex: pagination.current,
-        PageSize: pagination.pageSize
-      }
-    })
-    if (data.value?.status === 'success') {
-      teachers.value = data.value.data.items || []
-      pagination.total = data.value.data.totalrecord
+        PageSize: pagination.pageSize,
+      },
+    });
+    if (data.value?.status === "success") {
+      teachers.value = data.value.data.items || [];
+      pagination.total = data.value.data.totalrecord;
     } else {
-      teachers.value = []
-      pagination.total = 0
+      teachers.value = [];
+      pagination.total = 0;
     }
   } catch (err) {
-    console.error('Fetch teachers error', err)
+    console.error("Fetch teachers error", err);
   } finally {
-    loading.value = false
+    loading.value = false;
   }
 }
 
 async function selectTeacher(record) {
+  console.log("🚀 ~ selectTeacher ~ record:", record);
+
   if (!record) return
   selectedId.value = record.id
   try {
@@ -113,33 +101,43 @@ async function selectTeacher(record) {
 }
 
 async function handleSave() {
-  if (!selectedId.value) return
+  if (!selectedId.value) return;
   try {
-    saving.value = true
+    saving.value = true;
     const payload = {
       id_giao_vien: selectedId.value,
       chi_day_mot_buoi: onlyOneShift.value,
       so_tiet_toi_da: maxPeriod.value,
-      ds_Ca: schedule.value?.ds_Ca || []
-    }
-    await RestApi.teacher.update_avoid({ body: payload })
-    message.success('Cập nhật thành công')
+      ds_Ca: schedule.value?.ds_Ca || [],
+    };
+    await RestApi.teacher.update_avoid({ body: payload });
+    message.success("Cập nhật thành công");
   } catch (err) {
-    console.error('Update teacher error', err)
-    message.error('Lỗi cập nhật')
+    console.error("Update teacher error", err);
+    message.error("Lỗi cập nhật");
   } finally {
-    saving.value = false
+    saving.value = false;
   }
 }
 
 async function handleTableChange(pag) {
-  pagination.current = pag.current
-  pagination.pageSize = pag.pageSize
-  await fetchTeachers()
+  pagination.current = pag.current;
+  pagination.pageSize = pag.pageSize;
+  await fetchTeachers();
 }
 
-onMounted(fetchTeachers)
+const onRow = (record) => {
+  return {
+    onClick: () => {
+      selectTeacher(record)
+    },
+    style: {
+      cursor: 'pointer'
+    }
+  }
+}
+
+onMounted(fetchTeachers);
 </script>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/components/TeacherAvoid.vue
+++ b/components/TeacherAvoid.vue
@@ -33,7 +33,11 @@
         <span>Số tiết tối đa/ngày:</span>
         <a-input-number v-model:value="maxPeriod" :min="1" />
       </div>
-      <Timetable2 v-if="schedule.length" :data="schedule" class="mb-4" />
+      <div v-if="schedule" class="space-y-4">
+        <div v-for="block in schedule.ds_Ca" :key="block.id">
+          <Timetable :block="block" />
+        </div>
+      </div>
       <div class="text-right">
         <a-button type="primary" :loading="saving" @click="handleSave">Lưu</a-button>
       </div>
@@ -44,13 +48,13 @@
 <script setup>
 import { ref, reactive, onMounted } from 'vue'
 import { message } from 'ant-design-vue'
-import Timetable2 from './Timetable2.vue'
+import Timetable from './Timetable.vue'
 const { RestApi } = useApi()
 
 const teachers = ref([])
 const loading = ref(false)
 const selectedId = ref(null)
-const schedule = ref([])
+const schedule = ref()
 const onlyOneShift = ref(false)
 const maxPeriod = ref(10)
 const saving = ref(false)
@@ -97,11 +101,12 @@ async function selectTeacher(record) {
   if (!record) return
   selectedId.value = record.id
   try {
-    const { data } = await RestApi.teacher.detail({ params: { id: record.id } })
-    const info = data.value?.data || {}
-    schedule.value = info.ds_tiet_tranh_xep || []
-    onlyOneShift.value = !!info.chi_day_1_buoi
-    maxPeriod.value = info.so_tiet_toi_da || 10
+    const { data } = await RestApi.teacher.get_avoid({ params: { Id: record.id } })
+    if (data.value?.status === 'success') {
+      schedule.value = data.value.data
+      onlyOneShift.value = !!data.value.data.chi_day_mot_buoi
+      maxPeriod.value = data.value.data.so_tiet_toi_da || 0
+    }
   } catch (err) {
     console.error('Fetch teacher detail error', err)
   }
@@ -111,14 +116,13 @@ async function handleSave() {
   if (!selectedId.value) return
   try {
     saving.value = true
-    await RestApi.teacher.update({
-      body: {
-        id: selectedId.value,
-        ds_tiet_tranh_xep: schedule.value,
-        chi_day_1_buoi: onlyOneShift.value,
-        so_tiet_toi_da: maxPeriod.value
-      }
-    })
+    const payload = {
+      id_giao_vien: selectedId.value,
+      chi_day_mot_buoi: onlyOneShift.value,
+      so_tiet_toi_da: maxPeriod.value,
+      ds_Ca: schedule.value?.ds_Ca || []
+    }
+    await RestApi.teacher.update_avoid({ body: payload })
     message.success('Cập nhật thành công')
   } catch (err) {
     console.error('Update teacher error', err)

--- a/components/TeacherAvoid.vue
+++ b/components/TeacherAvoid.vue
@@ -15,12 +15,14 @@
     </a-card>
 
     <a-card title="CÁC TIẾT HỌC TRÁNH XẾP" class="md:col-span-1">
-      <div class="mb-4 flex items-center gap-2">
-        <a-checkbox v-model:checked="onlyOneShift">Chỉ dạy 1 buổi/ngày</a-checkbox>
-      </div>
-      <div class="mb-4 flex items-center gap-2">
-        <span>Số tiết tối đa/ngày:</span>
-        <a-input-number v-model:value="maxPeriod" :min="1" />
+      <div class="grid grid-cols-2 gap-2">
+        <div class="flex items-center">
+          <a-checkbox v-model:checked="onlyOneShift">Chỉ dạy 1 buổi/ngày</a-checkbox>
+        </div>
+        <div class="flex items-center gap-5">
+          <span>Số tiết tối đa/ngày:</span>
+          <a-input-number v-model:value="maxPeriod" :min="1" />
+        </div>
       </div>
       <div v-if="schedule" class="space-y-4">
         <div v-for="block in schedule.ds_Ca" :key="block.id">
@@ -42,7 +44,8 @@ const loading = ref(false);
 const selectedId = ref(null);
 const schedule = ref();
 const onlyOneShift = ref(false);
-const maxPeriod = ref(10);
+const maxPeriod = ref(0);
+const teaching_session = ref(null);
 const saving = ref(false);
 
 const columns = [
@@ -84,19 +87,19 @@ async function fetchTeachers() {
 }
 
 async function selectTeacher(record) {
-  console.log("🚀 ~ selectTeacher ~ record:", record);
-
-  if (!record) return
-  selectedId.value = record.id
+  if (!record) return;
+  selectedId.value = record.id;
   try {
-    const { data } = await RestApi.teacher.get_avoid({ params: { Id: record.id } })
-    if (data.value?.status === 'success') {
-      schedule.value = data.value.data
-      onlyOneShift.value = !!data.value.data.chi_day_mot_buoi
-      maxPeriod.value = data.value.data.so_tiet_toi_da || 0
+    const { data } = await RestApi.teacher.get_avoid({ params: { Id: record.id } });
+    console.log("🚀 ~ selectTeacher ~ data:", data);
+    if (data.value?.status === "success") {
+      schedule.value = data.value.data;
+      onlyOneShift.value = !!data.value.data.chi_day_mot_buoi;
+      maxPeriod.value = data.value.data.so_tiet_toi_da || 0;
+      teaching_session.value = data.value.data.id_buoi_day || 0;
     }
   } catch (err) {
-    console.error('Fetch teacher detail error', err)
+    console.error("Fetch teacher detail error", err);
   }
 }
 
@@ -108,10 +111,10 @@ async function handleSave() {
       id_giao_vien: selectedId.value,
       chi_day_mot_buoi: onlyOneShift.value,
       so_tiet_toi_da: maxPeriod.value,
+      id_buoi_day: teaching_session.value,
       ds_Ca: schedule.value?.ds_Ca || [],
     };
     await RestApi.teacher.update_avoid({ body: payload });
-    message.success("Cập nhật thành công");
   } catch (err) {
     console.error("Update teacher error", err);
     message.error("Lỗi cập nhật");
@@ -126,16 +129,16 @@ async function handleTableChange(pag) {
   await fetchTeachers();
 }
 
-const onRow = (record) => {
+const onRow = record => {
   return {
     onClick: () => {
-      selectTeacher(record)
+      selectTeacher(record);
     },
     style: {
-      cursor: 'pointer'
-    }
-  }
-}
+      cursor: "pointer",
+    },
+  };
+};
 
 onMounted(fetchTeachers);
 </script>

--- a/components/TeacherAvoid.vue
+++ b/components/TeacherAvoid.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <a-card title="DANH SÁCH GIÁO VIÊN" class="md:col-span-1">
+      <a-table
+        :columns="columns"
+        :data-source="teachers"
+        :loading="loading"
+        :pagination="pagination"
+        size="small"
+        row-key="id"
+        @change="handleTableChange"
+        @rowClick="selectTeacher"
+      >
+        <template #bodyCell="{ column, record, index }">
+          <template v-if="column.key === 'stt'">
+            {{ (pagination.current - 1) * pagination.pageSize + index + 1 }}
+          </template>
+          <template v-if="column.key === 'code'">
+            {{ record.ma_giao_vien }}
+          </template>
+          <template v-if="column.key === 'name'">
+            {{ record.ho_va_ho_dem }} {{ record.ten }}
+          </template>
+        </template>
+      </a-table>
+    </a-card>
+
+    <a-card title="CÁC TIẾT HỌC TRÁNH XẾP" class="md:col-span-1">
+      <div class="mb-4 flex items-center gap-2">
+        <a-checkbox v-model:checked="onlyOneShift">Chỉ dạy 1 buổi/ngày</a-checkbox>
+      </div>
+      <div class="mb-4 flex items-center gap-2">
+        <span>Số tiết tối đa/ngày:</span>
+        <a-input-number v-model:value="maxPeriod" :min="1" />
+      </div>
+      <Timetable2 v-if="schedule.length" :data="schedule" class="mb-4" />
+      <div class="text-right">
+        <a-button type="primary" :loading="saving" @click="handleSave">Lưu</a-button>
+      </div>
+    </a-card>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { message } from 'ant-design-vue'
+import Timetable2 from './Timetable2.vue'
+const { RestApi } = useApi()
+
+const teachers = ref([])
+const loading = ref(false)
+const selectedId = ref(null)
+const schedule = ref([])
+const onlyOneShift = ref(false)
+const maxPeriod = ref(10)
+const saving = ref(false)
+
+const columns = [
+  { title: 'STT', key: 'stt', width: 60, align: 'center' },
+  { title: 'Mã giáo viên', key: 'code' },
+  { title: 'Họ và tên', key: 'name' }
+]
+
+const pagination = reactive({
+  current: 1,
+  pageSize: 10,
+  total: 0,
+  showSizeChanger: true,
+  pageSizeOptions: ['10', '20', '50'],
+  showTotal: total => `Tổng ${total} bản ghi`
+})
+
+async function fetchTeachers() {
+  try {
+    loading.value = true
+    const { data } = await RestApi.teacher.list({
+      params: {
+        PageIndex: pagination.current,
+        PageSize: pagination.pageSize
+      }
+    })
+    if (data.value?.status === 'success') {
+      teachers.value = data.value.data.items || []
+      pagination.total = data.value.data.totalrecord
+    } else {
+      teachers.value = []
+      pagination.total = 0
+    }
+  } catch (err) {
+    console.error('Fetch teachers error', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function selectTeacher(record) {
+  if (!record) return
+  selectedId.value = record.id
+  try {
+    const { data } = await RestApi.teacher.detail({ params: { id: record.id } })
+    const info = data.value?.data || {}
+    schedule.value = info.ds_tiet_tranh_xep || []
+    onlyOneShift.value = !!info.chi_day_1_buoi
+    maxPeriod.value = info.so_tiet_toi_da || 10
+  } catch (err) {
+    console.error('Fetch teacher detail error', err)
+  }
+}
+
+async function handleSave() {
+  if (!selectedId.value) return
+  try {
+    saving.value = true
+    await RestApi.teacher.update({
+      body: {
+        id: selectedId.value,
+        ds_tiet_tranh_xep: schedule.value,
+        chi_day_1_buoi: onlyOneShift.value,
+        so_tiet_toi_da: maxPeriod.value
+      }
+    })
+    message.success('Cập nhật thành công')
+  } catch (err) {
+    console.error('Update teacher error', err)
+    message.error('Lỗi cập nhật')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function handleTableChange(pag) {
+  pagination.current = pag.current
+  pagination.pageSize = pag.pageSize
+  await fetchTeachers()
+}
+
+onMounted(fetchTeachers)
+</script>
+
+<style scoped>
+</style>

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -60,6 +60,7 @@ let ENDPOINTS = {
 
   TEACHER: "/api/giaovien",
   TEACHER_DETAIL: "/api/giaovien/detail",
+  TEACHER_AVOID: "/api/giaovien/tiettranhxep",
   
   S3: "/api/presigned_url",
 };
@@ -617,6 +618,12 @@ class Teacher{
   }
   async update(data) {
     return await this.request.put(ENDPOINTS.TEACHER, data);
+  }
+  async get_avoid(data) {
+    return await this.request.get(ENDPOINTS.TEACHER_AVOID, data);
+  }
+  async update_avoid(data) {
+    return await this.request.post(ENDPOINTS.TEACHER_AVOID, data);
   }
   async delete(data) {
     return await this.request.delete(ENDPOINTS.TEACHER, data);

--- a/pages/category_management/teacher.vue
+++ b/pages/category_management/teacher.vue
@@ -47,7 +47,7 @@
           <a-input v-model:value="formState.ten" placeholder="Nhập tên" :maxlength="200" show-count />
         </a-form-item>
         <SelectExpertise v-model="formState.id_to_chuyen_mon" name="id_to_chuyen_mon" />
-        <SelectSchoolSite v-model="formState.diem_truong" name="diem_truong" />
+        <SelectSchoolSite v-model="formState.id_diem_truong" name="id_diem_truong" :multiple="true" />
       </a-form>
 
       <template #footer>
@@ -98,7 +98,7 @@ const formState = reactive({
   ho_va_ho_dem: '',
   ten: '',
   id_to_chuyen_mon: undefined,
-  diem_truong: undefined
+  id_diem_truong: []
 });
 
 const rules = reactive({
@@ -113,7 +113,7 @@ const rules = reactive({
   id_to_chuyen_mon: [
     { required: true, message: 'Vui lòng chọn tổ chuyên môn', trigger: 'change' }
   ],
-  diem_truong: [
+  id_diem_truong: [
     { required: true, message: 'Vui lòng chọn điểm trường', trigger: 'change' }
   ]
 });
@@ -153,7 +153,7 @@ const handleSearch = async () => {
 
 const showModal = () => {
   isEdit.value = false;
-  Object.assign(formState, { id: null, ho_va_ho_dem: '', ten: '', id_to_chuyen_mon: undefined, diem_truong: undefined });
+  Object.assign(formState, { id: null, ho_va_ho_dem: '', ten: '', id_to_chuyen_mon: undefined, id_diem_truong: [] });
   visible.value = true;
 };
 
@@ -167,7 +167,7 @@ const editItem = async (id) => {
         ho_va_ho_dem: data.value.data.ho_va_ho_dem,
         ten: data.value.data.ten,
         id_to_chuyen_mon: data.value.data.id_to_chuyen_mon,
-        diem_truong: data.value.data.id_don_vi
+        id_diem_truong: data.value.data.id_diem_truong
       });
       visible.value = true;
     }

--- a/pages/demo/teacherAvoid.vue
+++ b/pages/demo/teacherAvoid.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="max-w-4xl mx-auto p-6 space-y-4">
+    <a-button @click="drawerOpen = true">Giáo viên tránh xếp</a-button>
+    <a-drawer
+      v-model:open="drawerOpen"
+      title="Giáo viên tránh xếp"
+      :footer="null"
+      height="100vh"
+      placement="bottom"
+    >
+      <TeacherAvoid />
+    </a-drawer>
+  </div>
+</template>
+
+<script setup>
+import TeacherAvoid from '~/components/TeacherAvoid.vue'
+const drawerOpen = ref(false)
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- add `TeacherAvoid.vue` component to manage teacher scheduling restrictions
- create demo page `teacherAvoid.vue` showing component inside a drawer
- add pagination support to the teacher list

## Testing
- `yarn install`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_6886f2e3be988326a3249cd6faae6bf6