### PR TITLE
Use new subject class API in SubjectList

### DIFF
--- a/components/SubjectList.vue
+++ b/components/SubjectList.vue
@@ -4,7 +4,7 @@
     :data-source="subjects"
     :pagination="false"
     size="small"
-    row-key="id_mon"
+    row-key="id"
     :customRow="onRow"
   >
     <template #bodyCell="{ column, record, index }">
@@ -12,24 +12,13 @@
         {{ index + 1 }}
       </template>
       <template v-else-if="column.key === 'trad'">
-        {{
-          (record.so_tiet_ca_sang_truyen_thong || 0) +
-            (record.so_tiet_ca_chieu_truyen_thong || 0)
-        }}
+        {{ record.so_tiet_phong_truyen_thong }}
       </template>
       <template v-else-if="column.key === 'spec'">
-        {{
-          (record.so_tiet_ca_sang_phong_chuyen_dung || 0) +
-            (record.so_tiet_ca_chieu_phong_chuyen_dung || 0)
-        }}
+        {{ record.so_tiet_phong_chuyen_dung }}
       </template>
       <template v-else-if="column.key === 'period'">
-        {{
-          (record.so_tiet_ca_sang_truyen_thong || 0) +
-            (record.so_tiet_ca_chieu_truyen_thong || 0) +
-            (record.so_tiet_ca_sang_phong_chuyen_dung || 0) +
-            (record.so_tiet_ca_chieu_phong_chuyen_dung || 0)
-        }}
+        {{ record.tong_so_tiet }}
       </template>
     </template>
   </a-table>
@@ -59,7 +48,7 @@ const subjects = ref([])
 // )
 const columns = [
   { title: 'STT', key: 'stt', width: 60, align: 'center' },
-  { title: 'Tên môn học', dataIndex: 'ten_mon', key: 'name' },
+  { title: 'Tên môn học', dataIndex: 'ten', key: 'name' },
    { title: 'Số tiết', key: 'period', align: 'center' },
   {
     title: 'Tổng số tiết',
@@ -73,9 +62,9 @@ const columns = [
 
 async function fetchSubjects(id) {
   try {
-    const { data } = await RestApi.class.get_subjects({ params: { idLop: id } })
+    const { data } = await RestApi.subject.get_by_class({ params: { idLop: id } })
     if (data.value?.status === 'success') {
-      subjects.value = data.value.data?.ds_mon || []
+      subjects.value = data.value.data?.items || []
     } else {
       subjects.value = []
     }

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -25,6 +25,7 @@ let ENDPOINTS = {
   SUBJECT: "/api/monhoc",
   SUBJECT_DETAIL: "/api/monhoc/detail",
   SUBJECT_AVOID: "/api/monhoc/tiettranhxep",
+  SUBJECT_CLASS: "/api/monhoc/monlop",
   //EXPERTISE
   EXPERTISE: "/api/tochuyenmon",
   //GRADE_LEVEL
@@ -513,6 +514,9 @@ class Subject {
   }
   async update_avoid(data) {
     return await this.request.post(ENDPOINTS.SUBJECT_AVOID, data);
+  }
+  async get_by_class(data) {
+    return await this.request.get(ENDPOINTS.SUBJECT_CLASS, data);
   }
 }
 class SchoolDay {


### PR DESCRIPTION
## Summary
- register new `SUBJECT_CLASS` API endpoint and `get_by_class` method
- fetch class subjects using `/api/monhoc/monlop` in `SubjectList`
- adjust displayed data fields for the new response

## Testing
- `yarn install --frozen-lockfile`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_6889f5c6fab483269d8bb8cca79afd1f