### PR TITLE
Add GradeClassList button and drawer

### DIFF
--- a/pages/category_management/class.vue
+++ b/pages/category_management/class.vue
@@ -5,6 +5,7 @@
       <a-button @click="resetForm" class="w-full md:w-auto">Đặt lại</a-button>
       <a-button type="primary" @click="drawerBreakOpen = true" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Tiết nghỉ</a-button>
       <a-button type="primary" @click="drawerAvoidOpen = true" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Tiết tránh xếp của cặp Lớp - Môn học</a-button>
+      <a-button type="primary" @click="drawerSubjectOpen = true" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Môn học của lớp</a-button>
       <a-button type="primary" @click="showModal" class="w-full md:w-auto" :disabled="!settingStore.currentPermission">Thêm mới</a-button>
     </div>
 
@@ -79,6 +80,18 @@
         <ClassSubjectAvoid ref="avoidRef" />
       </ClientOnly>
     </a-drawer>
+    <a-drawer
+      v-model:open="drawerSubjectOpen"
+      title="Môn học của lớp"
+      :footer="null"
+      height="100vh"
+      placement="bottom"
+      @close="closeClassSubject"
+    >
+      <ClientOnly>
+        <GradeClassList ref="gradeClassRef" />
+      </ClientOnly>
+    </a-drawer>
   </div>
 </template>
 
@@ -92,12 +105,19 @@ const breakRef = ref(null)
 const drawerAvoidOpen = ref(false)
 const avoidRef = ref(null)
 
+const drawerSubjectOpen = ref(false)
+const gradeClassRef = ref(null)
+
 const closeClassBreak = () => {
   breakRef.value?.reset()
 }
 
 const closeSubjectAvoid = () => {
   avoidRef.value?.reset()
+}
+
+const closeClassSubject = () => {
+  gradeClassRef.value?.reset()
 }
 
 watch(drawerBreakOpen, val => {
@@ -109,6 +129,12 @@ watch(drawerBreakOpen, val => {
 watch(drawerAvoidOpen, val => {
   if (val) {
     avoidRef.value?.refresh()
+  }
+})
+
+watch(drawerSubjectOpen, val => {
+  if (val) {
+    gradeClassRef.value?.refresh()
   }
 })
 


### PR DESCRIPTION
## Summary
- add "Môn học của lớp" button on class page
- show `GradeClassList` in a drawer to manage class subjects

## Testing
- `yarn install --frozen-lockfile`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_688b109db5408326b311b3b6e6d59145