### PR TITLE
Add GradeSubjectAvoid demo

### DIFF
--- a/components/GradeSubjectAvoid.vue
+++ b/components/GradeSubjectAvoid.vue
@@ -55,14 +55,10 @@ const columns = [
   { title: 'Tên môn học', dataIndex: 'ten', key: 'name' },
 ]
 
-async function fetchSubjects(grade, ship) {
-  if (!grade || !ship) {
-    subjects.value = []
-    return
-  }
+async function fetchSubjects() {
   try {
     loading.value = true
-    const { data } = await RestApi.subject.list({ params: { id_khoi: grade, id_ban: ship } })
+    const { data } = await RestApi.subject.list()
     if (data.value?.status === 'success') {
       subjects.value = data.value.data.items || []
     } else {
@@ -75,10 +71,10 @@ async function fetchSubjects(grade, ship) {
   }
 }
 
-watch([gradeId, shipId], ([g, b]) => {
+watch([gradeId, shipId], () => {
   selectedId.value = null
   schedule.value = undefined
-  fetchSubjects(g, b)
+  fetchSubjects()
 }, { immediate: true })
 
 watch([gradeId, shipId, selectedId], async ([g, b, id]) => {
@@ -130,7 +126,7 @@ const reset = () => {
 }
 
 const refresh = async () => {
-  await fetchSubjects(gradeId.value, shipId.value)
+  await fetchSubjects()
   if (gradeId.value && shipId.value && selectedId.value) {
     const { data } = await RestApi.subject_grade_level.get_avoid({
       params: { id_khoi: gradeId.value, id_ban: shipId.value, id_mon: selectedId.value }

--- a/components/GradeSubjectAvoid.vue
+++ b/components/GradeSubjectAvoid.vue
@@ -14,7 +14,7 @@
         row-key="id"
         :customRow="onRow"
       >
-        <template #bodyCell="{ column, record, index }">
+        <template #bodyCell="{ column, index }">
           <template v-if="column.key === 'stt'">{{ index + 1 }}</template>
         </template>
       </a-table>
@@ -55,10 +55,14 @@ const columns = [
   { title: 'Tên môn học', dataIndex: 'ten', key: 'name' },
 ]
 
-async function fetchSubjects() {
+async function fetchSubjects(grade, ship) {
+  if (!grade || !ship) {
+    subjects.value = []
+    return
+  }
   try {
     loading.value = true
-    const { data } = await RestApi.subject.list()
+    const { data } = await RestApi.subject.list({ params: { id_khoi: grade, id_ban: ship } })
     if (data.value?.status === 'success') {
       subjects.value = data.value.data.items || []
     } else {
@@ -71,10 +75,10 @@ async function fetchSubjects() {
   }
 }
 
-watch([gradeId, shipId], () => {
+watch([gradeId, shipId], ([g, b]) => {
   selectedId.value = null
   schedule.value = undefined
-  fetchSubjects()
+  fetchSubjects(g, b)
 }, { immediate: true })
 
 watch([gradeId, shipId, selectedId], async ([g, b, id]) => {
@@ -126,7 +130,7 @@ const reset = () => {
 }
 
 const refresh = async () => {
-  await fetchSubjects()
+  await fetchSubjects(gradeId.value, shipId.value)
   if (gradeId.value && shipId.value && selectedId.value) {
     const { data } = await RestApi.subject_grade_level.get_avoid({
       params: { id_khoi: gradeId.value, id_ban: shipId.value, id_mon: selectedId.value }

--- a/components/GradeSubjectAvoid.vue
+++ b/components/GradeSubjectAvoid.vue
@@ -1,0 +1,154 @@
+<template>
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-1">
+    <a-card title="DANH SÁCH MÔN HỌC" class="md:col-span-1">
+      <div class="grid grid-cols-2 gap-2 mb-2">
+        <SelectGradeLevel v-model="gradeId" />
+        <SelectSchoolship v-model="shipId" />
+      </div>
+      <a-table
+        :columns="columns"
+        :data-source="subjects"
+        :loading="loading"
+        :pagination="false"
+        size="small"
+        row-key="id"
+        :customRow="onRow"
+      >
+        <template #bodyCell="{ column, record, index }">
+          <template v-if="column.key === 'stt'">{{ index + 1 }}</template>
+        </template>
+      </a-table>
+    </a-card>
+    <a-card
+      v-if="gradeId && shipId && selectedId"
+      title="CÁC TIẾT HỌC TRÁNH XẾP"
+      class="md:col-span-2"
+    >
+      <div v-if="schedule" class="space-y-4">
+        <div v-for="block in schedule.ds_Ca" :key="block.id">
+          <Timetable :block="block" />
+        </div>
+      </div>
+      <div class="flex justify-end gap-2 mt-2">
+        <a-button type="primary" :loading="saving" @click="handleSave">Lưu</a-button>
+        <a-button danger @click="reset">Hủy</a-button>
+      </div>
+    </a-card>
+  </div>
+</template>
+
+<script setup>
+import { message } from 'ant-design-vue'
+const { RestApi } = useApi()
+
+const gradeId = ref(null)
+const shipId = ref(null)
+const subjects = ref([])
+const loading = ref(false)
+const selectedId = ref(null)
+const schedule = ref()
+const saving = ref(false)
+
+const columns = [
+  { title: 'STT', key: 'stt', width: 60, align: 'center' },
+  { title: 'Mã môn học', dataIndex: 'ma', key: 'code' },
+  { title: 'Tên môn học', dataIndex: 'ten', key: 'name' },
+]
+
+async function fetchSubjects(grade, ship) {
+  if (!grade || !ship) {
+    subjects.value = []
+    return
+  }
+  try {
+    loading.value = true
+    const { data } = await RestApi.subject.list({ params: { id_khoi: grade, id_ban: ship } })
+    if (data.value?.status === 'success') {
+      subjects.value = data.value.data.items || []
+    } else {
+      subjects.value = []
+    }
+  } catch (err) {
+    console.error('Fetch subjects error', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+watch([gradeId, shipId], ([g, b]) => {
+  selectedId.value = null
+  schedule.value = undefined
+  fetchSubjects(g, b)
+}, { immediate: true })
+
+watch([gradeId, shipId, selectedId], async ([g, b, id]) => {
+  if (g && b && id) {
+    try {
+      const { data } = await RestApi.subject_grade_level.get_avoid({
+        params: { id_khoi: g, id_ban: b, id_mon: id }
+      })
+      if (data.value?.status === 'success') {
+        schedule.value = data.value.data
+      } else {
+        schedule.value = undefined
+      }
+    } catch (err) {
+      console.error('Fetch avoid schedule error', err)
+    }
+  } else {
+    schedule.value = undefined
+  }
+})
+
+async function handleSave() {
+  if (!gradeId.value || !shipId.value || !selectedId.value) return
+  try {
+    saving.value = true
+    const payload = {
+      id_khoi: gradeId.value,
+      id_ban: shipId.value,
+      id_mon: selectedId.value,
+      ds_Ca: schedule.value?.ds_Ca || [],
+    }
+    const { data, error } = await RestApi.subject_grade_level.update_avoid({ body: payload })
+    if (data.value?.status === 'success') {
+      message.success(data.value.message || 'Cập nhật thành công')
+    } else {
+      throw new Error(error.value?.data?.message || data.value?.message || 'Cập nhật không thành công')
+    }
+  } catch (err) {
+    console.error('Update avoid error', err)
+    message.error(err.message || 'Lỗi cập nhật')
+  } finally {
+    saving.value = false
+  }
+}
+
+const reset = () => {
+  selectedId.value = null
+  schedule.value = undefined
+}
+
+const refresh = async () => {
+  await fetchSubjects(gradeId.value, shipId.value)
+  if (gradeId.value && shipId.value && selectedId.value) {
+    const { data } = await RestApi.subject_grade_level.get_avoid({
+      params: { id_khoi: gradeId.value, id_ban: shipId.value, id_mon: selectedId.value }
+    })
+    if (data.value?.status === 'success') {
+      schedule.value = data.value.data
+    }
+  }
+}
+
+defineExpose({ reset, refresh })
+
+const onRow = record => {
+  return {
+    onClick: () => { selectedId.value = record.id },
+    style: { cursor: 'pointer' }
+  }
+}
+</script>
+
+<style scoped></style>

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -56,6 +56,7 @@ let ENDPOINTS = {
   ///api/phonghoc/tietban
 
   SUBJECT_GRADE_LEVEL: "/api/monhoc/monkhoilop",
+  SUBJECT_GRADE_LEVEL_AVOID: "/api/monhoc/monkhoilop/tiettranhxep",
 
   SUBJECT_COMBINATION: "/api/tohopmon",
 
@@ -595,6 +596,12 @@ class SubjectGradeLevel {
   }
   async delete(data) {
     return await this.request.delete(ENDPOINTS.SUBJECT_GRADE_LEVEL, data);
+  }
+  async get_avoid(data) {
+    return await this.request.get(ENDPOINTS.SUBJECT_GRADE_LEVEL_AVOID, data);
+  }
+  async update_avoid(data) {
+    return await this.request.post(ENDPOINTS.SUBJECT_GRADE_LEVEL_AVOID, data);
   }
 }
 

--- a/pages/category_management/subject_grade_level.vue
+++ b/pages/category_management/subject_grade_level.vue
@@ -71,6 +71,18 @@
           </template>
         </a-table>
       </ClientOnly>
+    <a-drawer
+      v-model:open="drawerAvoidOpen"
+      title="Thiết lập tiết tránh xếp của môn học theo khối"
+      :footer="null"
+      height="100vh"
+      placement="bottom"
+      @close="closeDrawerAvoid"
+    >
+      <ClientOnly>
+        <GradeSubjectAvoid ref="avoidRef" />
+      </ClientOnly>
+    </a-drawer>
     </div>
   </div>
 </template>
@@ -96,6 +108,20 @@ const summary = reactive({
 });
 
 const subjects = ref([]);
+
+const drawerAvoidOpen = ref(false)
+const avoidRef = ref(null)
+
+const closeDrawerAvoid = () => {
+  avoidRef.value?.reset?.()
+}
+
+watch(drawerAvoidOpen, val => {
+  if (val) {
+    avoidRef.value?.refresh?.()
+  }
+})
+
 
 const baseColumns = [
   {
@@ -198,9 +224,9 @@ const onEditableChange = (record) => {
 
 
 const handleAvoid = () => {
-  // TODO: Implement avoid schedule logic
-  console.log('Tiết tránh xếp clicked');
-};
+  drawerAvoidOpen.value = true
+}
+
 
 const handleUpdate = async () => {
   try {

--- a/pages/demo/subjectgradeavoid.vue
+++ b/pages/demo/subjectgradeavoid.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="max-w-5xl mx-auto p-6 space-y-6">
+    <h1 class="text-2xl font-bold">Demo: GradeSubjectAvoid</h1>
+    <a-button type="primary" @click="drawerOpen = true">Mở demo</a-button>
+    <a-drawer
+      v-model:open="drawerOpen"
+      title="GradeSubjectAvoid Demo"
+      :footer="null"
+      height="100vh"
+      placement="bottom"
+      @close="closeDrawer"
+    >
+      <ClientOnly>
+        <GradeSubjectAvoid ref="avoidRef" />
+      </ClientOnly>
+    </a-drawer>
+  </div>
+</template>
+
+<script setup>
+const drawerOpen = ref(false)
+const avoidRef = ref(null)
+
+watch(drawerOpen, val => {
+  if (val) {
+    avoidRef.value?.refresh?.()
+  }
+})
+
+const closeDrawer = () => {
+  avoidRef.value?.reset?.()
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- implement GradeSubjectAvoid component
- expose new API methods for grade-level subject avoid schedule
- create demo page using the component in a drawer

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_688b320699448326a7782a3ecdea6801