### PR TITLE
feat: add timetable management page

### DIFF
--- a/components/TimetableInfo.vue
+++ b/components/TimetableInfo.vue
@@ -14,6 +14,13 @@ const arrangePartial = type => {
 const cancelArrange = () => {
   console.log("Hủy kết quả xếp");
 };
+
+const props = defineProps({
+  id: {
+    type: [Number, String],
+    // required: true
+  }
+})
 </script>
 
 <template>

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -71,6 +71,9 @@ let ENDPOINTS = {
   CLASS_SUBJECT: "/api/lopmon",
   CLASS_SUBJECT_AVOID: "/api/lopmon/tiettranhxep",
 
+  //TIMETABLE
+  TIMETABLE: "/api/thoikhoabieu",
+
   S3: "/api/presigned_url",
 };
 import { useUserStore } from "~~/stores/userStore";
@@ -174,6 +177,7 @@ class RestApi {
     this.subject_combination = new SubjectCombination(this.request);
     this.teacher = new Teacher(this.request);
     this.class = new Class(this.request);
+    this.timetable = new Timetable(this.request);
   }
   async get_url_upload(acl, content_encoding, content_type, key, platform) {
     let data = { acl, content_encoding, content_type, key, platform };
@@ -691,6 +695,24 @@ class Class {
   }
   async update_subject_avoid(data) {
     return await this.request.post(ENDPOINTS.CLASS_SUBJECT_AVOID, data);
+  }
+}
+
+class Timetable {
+  constructor() {
+    this.request = new Request();
+  }
+  async list(data) {
+    return await this.request.get(ENDPOINTS.TIMETABLE, data);
+  }
+  async create(data) {
+    return await this.request.post(ENDPOINTS.TIMETABLE, data);
+  }
+  async update(data) {
+    return await this.request.put(ENDPOINTS.TIMETABLE, data);
+  }
+  async delete(data) {
+    return await this.request.delete(ENDPOINTS.TIMETABLE, data);
   }
 }
 export default () => {

--- a/pages/list_management/timetable.vue
+++ b/pages/list_management/timetable.vue
@@ -124,7 +124,7 @@ const columns = [
   }
 ]
 
-const param = ref({ pageIndex: 1, pageSize: 10, search: '' })
+const param = ref({ pageIndex: 1, pageSize: 10 })
 
 const visible = ref(false)
 const isEdit = ref(false)
@@ -163,7 +163,12 @@ const handleTableChange = async (pag) => {
 }
 
 const handleSearch = async () => {
-  param.value.search = searchText.value
+  const search = searchText.value.trim()
+  if (search) {
+    param.value.search = search
+  } else {
+    delete param.value.search
+  }
   pagination.current = 1
   param.value.pageIndex = 1
   await fetchData({ ...param.value })
@@ -173,6 +178,7 @@ const resetSearch = async () => {
   searchText.value = ''
   pagination.current = 1
   param.value.pageIndex = 1
+  delete param.value.search
   await fetchData({ ...param.value })
 }
 

--- a/pages/list_management/timetable.vue
+++ b/pages/list_management/timetable.vue
@@ -1,2 +1,261 @@
 <template>
-  </template>
+  <div class="p-4 bg-white rounded shadow min-h-full">
+    <!-- Header -->
+    <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-6">
+      <a-input-search
+        v-model:value="searchText"
+        placeholder="Tìm kiếm thời khóa biểu..."
+        enter-button
+        @search="handleSearch"
+        class="w-full md:w-1/3"
+      />
+      <a-button @click="resetSearch" class="w-full md:w-auto">Đặt lại</a-button>
+      <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
+    </div>
+
+    <!-- Table -->
+    <ClientOnly>
+      <a-table
+        :columns="columns"
+        :data-source="dataSource"
+        :pagination="pagination"
+        :loading="loading"
+        @change="handleTableChange"
+        bordered
+        size="middle"
+      >
+        <template #bodyCell="{ column, record }">
+          <template v-if="column.key === 'status'">
+            <a-tag :color="record.dang_su_dung ? 'green' : 'red'">
+              {{ record.dang_su_dung ? 'Đang sử dụng' : 'Không sử dụng' }}
+            </a-tag>
+          </template>
+          <template v-else-if="column.key === 'action'">
+            <div class="flex justify-center gap-2">
+              <a-tooltip title="Sửa">
+                <a-button type="link" size="small" @click="editItem(record)">
+                  <template #icon><EditOutlined /></template>
+                </a-button>
+              </a-tooltip>
+              <a-popconfirm
+                title="Bạn chắc chắn muốn xóa?"
+                ok-text="Đồng ý"
+                cancel-text="Hủy"
+                @confirm="deleteItem(record.id)"
+              >
+                <a-tooltip title="Xóa">
+                  <a-button type="link" danger size="small">
+                    <template #icon><DeleteOutlined /></template>
+                  </a-button>
+                </a-tooltip>
+              </a-popconfirm>
+            </div>
+          </template>
+        </template>
+      </a-table>
+    </ClientOnly>
+
+    <!-- Modal -->
+    <a-modal
+      v-model:open="visible"
+      :title="isEdit ? 'Chỉnh sửa thời khóa biểu' : 'Thêm mới thời khóa biểu'"
+      @cancel="handleCancel"
+      :footer="null"
+    >
+      <a-form ref="formRef" :model="formState" layout="vertical" :rules="rules">
+        <a-form-item label="Tên thời khóa biểu" name="ten">
+          <a-input v-model:value="formState.ten" placeholder="Nhập tên thời khóa biểu" />
+        </a-form-item>
+        <a-form-item label="Đang sử dụng" name="dang_su_dung">
+          <a-switch v-model:checked="formState.dang_su_dung" />
+        </a-form-item>
+        <div class="flex justify-end gap-2 mt-6">
+          <a-button @click="handleCancel">Hủy</a-button>
+          <a-button type="primary" @click="handleOk" :loading="confirmLoading">
+            {{ isEdit ? 'Cập nhật' : 'Thêm mới' }}
+          </a-button>
+        </div>
+      </a-form>
+    </a-modal>
+  </div>
+</template>
+
+<script setup>
+const { RestApi } = useApi()
+
+const searchText = ref('')
+const dataSource = ref([])
+const loading = ref(false)
+
+const pagination = reactive({
+  current: 1,
+  pageSize: 10,
+  total: 0,
+  showSizeChanger: true,
+  pageSizeOptions: ['1', '5', '10', '20', '50'],
+  showTotal: total => `Tổng ${total} bản ghi`
+})
+
+const columns = [
+  {
+    title: 'STT',
+    key: 'stt',
+    width: 70,
+    align: 'center',
+    customRender: ({ index }) => (pagination.current - 1) * pagination.pageSize + index + 1
+  },
+  {
+    title: 'Tên thời khóa biểu',
+    dataIndex: 'ten',
+    key: 'ten'
+  },
+  {
+    title: 'Trạng thái',
+    dataIndex: 'dang_su_dung',
+    key: 'status',
+    width: 140,
+    align: 'center'
+  },
+  {
+    title: 'Thao tác',
+    key: 'action',
+    width: 120,
+    align: 'center'
+  }
+]
+
+const param = ref({ pageIndex: 1, pageSize: 10, search: '' })
+
+const visible = ref(false)
+const isEdit = ref(false)
+const formRef = ref()
+const confirmLoading = ref(false)
+const formState = reactive({ id: null, ten: '', dang_su_dung: true })
+
+const rules = {
+  ten: [{ required: true, message: 'Vui lòng nhập tên thời khóa biểu', trigger: 'blur' }]
+}
+
+const fetchData = async (p) => {
+  try {
+    loading.value = true
+    const { data } = await RestApi.timetable.list({ params: p })
+    if (data.value?.status === 'success') {
+      dataSource.value = data.value.data.items
+      pagination.total = data.value.data.totalrecord
+    } else {
+      dataSource.value = []
+      pagination.total = 0
+    }
+  } catch (error) {
+    message.error('Lỗi khi tải danh sách thời khóa biểu')
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleTableChange = async (pag) => {
+  pagination.current = pag.current
+  pagination.pageSize = pag.pageSize
+  param.value.pageIndex = pag.current
+  param.value.pageSize = pag.pageSize
+  await fetchData({ ...param.value })
+}
+
+const handleSearch = async () => {
+  param.value.search = searchText.value
+  pagination.current = 1
+  param.value.pageIndex = 1
+  await fetchData({ ...param.value })
+}
+
+const resetSearch = async () => {
+  searchText.value = ''
+  pagination.current = 1
+  param.value.pageIndex = 1
+  await fetchData({ ...param.value })
+}
+
+const showModal = () => {
+  isEdit.value = false
+  Object.assign(formState, { id: null, ten: '', dang_su_dung: true })
+  visible.value = true
+}
+
+const editItem = (record) => {
+  Object.assign(formState, {
+    id: record.id,
+    ten: record.ten,
+    dang_su_dung: record.dang_su_dung
+  })
+  isEdit.value = true
+  visible.value = true
+  formRef.value?.clearValidate()
+}
+
+const handleOk = async () => {
+  try {
+    await formRef.value.validate()
+    confirmLoading.value = true
+
+    if (isEdit.value) {
+      await RestApi.timetable.update({ body: { ...formState } })
+      message.success('Cập nhật thành công')
+    } else {
+      const { id, ...body } = formState
+      await RestApi.timetable.create({ body })
+      message.success('Thêm mới thành công')
+    }
+  } catch (error) {
+    message.error('Đã xảy ra lỗi khi lưu thông tin')
+  } finally {
+    visible.value = false
+    await fetchData({ ...param.value })
+    confirmLoading.value = false
+  }
+}
+
+const handleCancel = () => {
+  formRef.value?.resetFields()
+  visible.value = false
+}
+
+const deleteItem = async (id) => {
+  try {
+    await RestApi.timetable.delete({ params: { Id: id } })
+    message.success('Xóa thành công')
+  } catch (error) {
+    message.error('Đã xảy ra lỗi khi xóa')
+  } finally {
+    await fetchData({ ...param.value })
+  }
+}
+
+await fetchData({ ...param.value })
+</script>
+
+<style scoped>
+@media (max-width: 768px) {
+  .ant-table-thead > tr > th,
+  .ant-table-tbody > tr > td {
+    padding: 8px !important;
+    font-size: 13px;
+  }
+
+  .ant-table-content {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+.ant-table-cell-fix-left,
+.ant-table-cell-fix-right {
+  z-index: 1;
+  background: white;
+}
+
+.ant-table-cell-fix-right {
+  box-shadow: -5px 0 5px -5px rgba(0, 0, 0, 0.1);
+}
+</style>
+

--- a/pages/list_management/timetable.vue
+++ b/pages/list_management/timetable.vue
@@ -2,47 +2,33 @@
   <div class="p-4 bg-white rounded shadow min-h-full">
     <!-- Header -->
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-6">
-      <a-input-search
-        v-model:value="searchText"
-        placeholder="Tìm kiếm thời khóa biểu..."
-        enter-button
-        @search="handleSearch"
-        class="w-full md:w-1/3"
-      />
+      <a-input-search v-model:value="searchText" placeholder="Tìm kiếm thời khóa biểu..." enter-button @search="handleSearch" class="w-full md:w-1/3" />
       <a-button @click="resetSearch" class="w-full md:w-auto">Đặt lại</a-button>
       <a-button type="primary" @click="showModal" class="w-full md:w-auto">Thêm mới</a-button>
     </div>
 
     <!-- Table -->
     <ClientOnly>
-      <a-table
-        :columns="columns"
-        :data-source="dataSource"
-        :pagination="pagination"
-        :loading="loading"
-        @change="handleTableChange"
-        bordered
-        size="middle"
-      >
+      <a-table :columns="columns" :data-source="dataSource" :pagination="pagination" :loading="loading" @change="handleTableChange" bordered size="middle">
         <template #bodyCell="{ column, record }">
           <template v-if="column.key === 'status'">
             <a-tag :color="record.dang_su_dung ? 'green' : 'red'">
-              {{ record.dang_su_dung ? 'Đang sử dụng' : 'Không sử dụng' }}
+              {{ record.dang_su_dung ? "Đang sử dụng" : "Không sử dụng" }}
             </a-tag>
           </template>
           <template v-else-if="column.key === 'action'">
             <div class="flex justify-center gap-2">
+              <a-tooltip title="Thời khóa biểu">
+                <a-button type="link" size="small" @click="openInfoDrawer(record)">
+                  <template #icon><CalendarOutlined /></template>
+                </a-button>
+              </a-tooltip>
               <a-tooltip title="Sửa">
                 <a-button type="link" size="small" @click="editItem(record)">
                   <template #icon><EditOutlined /></template>
                 </a-button>
               </a-tooltip>
-              <a-popconfirm
-                title="Bạn chắc chắn muốn xóa?"
-                ok-text="Đồng ý"
-                cancel-text="Hủy"
-                @confirm="deleteItem(record.id)"
-              >
+              <a-popconfirm title="Bạn chắc chắn muốn xóa?" ok-text="Đồng ý" cancel-text="Hủy" @confirm="deleteItem(record.id)">
                 <a-tooltip title="Xóa">
                   <a-button type="link" danger size="small">
                     <template #icon><DeleteOutlined /></template>
@@ -56,12 +42,7 @@
     </ClientOnly>
 
     <!-- Modal -->
-    <a-modal
-      v-model:open="visible"
-      :title="isEdit ? 'Chỉnh sửa thời khóa biểu' : 'Thêm mới thời khóa biểu'"
-      @cancel="handleCancel"
-      :footer="null"
-    >
+    <a-modal v-model:open="visible" :title="isEdit ? 'Chỉnh sửa thời khóa biểu' : 'Thêm mới thời khóa biểu'" @cancel="handleCancel" :footer="null">
       <a-form ref="formRef" :model="formState" layout="vertical" :rules="rules">
         <a-form-item label="Tên thời khóa biểu" name="ten">
           <a-input v-model:value="formState.ten" placeholder="Nhập tên thời khóa biểu" />
@@ -72,196 +53,193 @@
         <div class="flex justify-end gap-2 mt-6">
           <a-button @click="handleCancel">Hủy</a-button>
           <a-button type="primary" @click="handleOk" :loading="confirmLoading">
-            {{ isEdit ? 'Cập nhật' : 'Thêm mới' }}
+            {{ isEdit ? "Cập nhật" : "Thêm mới" }}
           </a-button>
         </div>
       </a-form>
     </a-modal>
+    <a-drawer v-model:open="drawerInfoOpen" title="Xếp thời khóa biểu" :footer="null" height="100vh" placement="bottom" @close="closeInfoDrawer">
+      <ClientOnly>
+        <TimetableInfo ref="infoRef" />
+      </ClientOnly>
+    </a-drawer>
   </div>
 </template>
 
 <script setup>
-const { RestApi } = useApi()
+const { RestApi } = useApi();
 
-const searchText = ref('')
-const dataSource = ref([])
-const loading = ref(false)
+const searchText = ref("");
+const dataSource = ref([]);
+const loading = ref(false);
 
 const pagination = reactive({
   current: 1,
   pageSize: 10,
   total: 0,
   showSizeChanger: true,
-  pageSizeOptions: ['1', '5', '10', '20', '50'],
-  showTotal: total => `Tổng ${total} bản ghi`
-})
+  pageSizeOptions: ["1", "5", "10", "20", "50"],
+  showTotal: total => `Tổng ${total} bản ghi`,
+});
 
 const columns = [
   {
-    title: 'STT',
-    key: 'stt',
+    title: "STT",
+    key: "stt",
     width: 70,
-    align: 'center',
-    customRender: ({ index }) => (pagination.current - 1) * pagination.pageSize + index + 1
+    align: "center",
+    customRender: ({ index }) => (pagination.current - 1) * pagination.pageSize + index + 1,
   },
   {
-    title: 'Tên thời khóa biểu',
-    dataIndex: 'ten',
-    key: 'ten'
+    title: "Tên thời khóa biểu",
+    dataIndex: "ten",
+    key: "ten",
   },
   {
-    title: 'Trạng thái',
-    dataIndex: 'dang_su_dung',
-    key: 'status',
+    title: "Trạng thái",
+    dataIndex: "dang_su_dung",
+    key: "status",
     width: 140,
-    align: 'center'
+    align: "center",
   },
   {
-    title: 'Thao tác',
-    key: 'action',
+    title: "Thao tác",
+    key: "action",
     width: 120,
-    align: 'center'
-  }
-]
+    align: "center",
+  },
+];
 
-const param = ref({ pageIndex: 1, pageSize: 10 })
+const param = ref({ pageIndex: 1, pageSize: 10 });
 
-const visible = ref(false)
-const isEdit = ref(false)
-const formRef = ref()
-const confirmLoading = ref(false)
-const formState = reactive({ id: null, ten: '', dang_su_dung: true })
+const visible = ref(false);
+const isEdit = ref(false);
+const formRef = ref();
+const confirmLoading = ref(false);
+const formState = reactive({ id: null, ten: "", dang_su_dung: true });
 
 const rules = {
-  ten: [{ required: true, message: 'Vui lòng nhập tên thời khóa biểu', trigger: 'blur' }]
-}
+  ten: [{ required: true, message: "Vui lòng nhập tên thời khóa biểu", trigger: "blur" }],
+};
 
-const fetchData = async (p) => {
+const fetchData = async p => {
   try {
-    loading.value = true
-    const { data } = await RestApi.timetable.list({ params: p })
-    if (data.value?.status === 'success') {
-      dataSource.value = data.value.data.items
-      pagination.total = data.value.data.totalrecord
+    loading.value = true;
+    const { data } = await RestApi.timetable.list({ params: p });
+    if (data.value?.status === "success") {
+      dataSource.value = data.value.data.items;
+      pagination.total = data.value.data.totalrecord;
     } else {
-      dataSource.value = []
-      pagination.total = 0
+      dataSource.value = [];
+      pagination.total = 0;
     }
   } catch (error) {
-    message.error('Lỗi khi tải danh sách thời khóa biểu')
+    message.error("Lỗi khi tải danh sách thời khóa biểu");
   } finally {
-    loading.value = false
+    loading.value = false;
   }
-}
+};
 
-const handleTableChange = async (pag) => {
-  pagination.current = pag.current
-  pagination.pageSize = pag.pageSize
-  param.value.pageIndex = pag.current
-  param.value.pageSize = pag.pageSize
-  await fetchData({ ...param.value })
-}
+const handleTableChange = async pag => {
+  pagination.current = pag.current;
+  pagination.pageSize = pag.pageSize;
+  param.value.pageIndex = pag.current;
+  param.value.pageSize = pag.pageSize;
+  await fetchData({ ...param.value });
+};
 
 const handleSearch = async () => {
-  const search = searchText.value.trim()
+  const search = searchText.value.trim();
   if (search) {
-    param.value.search = search
+    param.value.search = search;
   } else {
-    delete param.value.search
+    delete param.value.search;
   }
-  pagination.current = 1
-  param.value.pageIndex = 1
-  await fetchData({ ...param.value })
-}
+  pagination.current = 1;
+  param.value.pageIndex = 1;
+  await fetchData({ ...param.value });
+};
 
 const resetSearch = async () => {
-  searchText.value = ''
-  pagination.current = 1
-  param.value.pageIndex = 1
-  delete param.value.search
-  await fetchData({ ...param.value })
-}
+  searchText.value = "";
+  pagination.current = 1;
+  param.value.pageIndex = 1;
+  delete param.value.search;
+  await fetchData({ ...param.value });
+};
 
 const showModal = () => {
-  isEdit.value = false
-  Object.assign(formState, { id: null, ten: '', dang_su_dung: true })
-  visible.value = true
-}
+  isEdit.value = false;
+  Object.assign(formState, { id: null, ten: "", dang_su_dung: true });
+  visible.value = true;
+};
 
-const editItem = (record) => {
+const editItem = record => {
   Object.assign(formState, {
     id: record.id,
     ten: record.ten,
-    dang_su_dung: record.dang_su_dung
-  })
-  isEdit.value = true
-  visible.value = true
-  formRef.value?.clearValidate()
-}
+    dang_su_dung: record.dang_su_dung,
+  });
+  isEdit.value = true;
+  visible.value = true;
+  formRef.value?.clearValidate();
+};
 
 const handleOk = async () => {
   try {
-    await formRef.value.validate()
-    confirmLoading.value = true
+    await formRef.value.validate();
+    confirmLoading.value = true;
 
     if (isEdit.value) {
-      await RestApi.timetable.update({ body: { ...formState } })
-      message.success('Cập nhật thành công')
+      await RestApi.timetable.update({ body: { ...formState } });
+      message.success("Cập nhật thành công");
     } else {
-      const { id, ...body } = formState
-      await RestApi.timetable.create({ body })
-      message.success('Thêm mới thành công')
+      const { id, ...body } = formState;
+      await RestApi.timetable.create({ body });
+      message.success("Thêm mới thành công");
     }
   } catch (error) {
-    message.error('Đã xảy ra lỗi khi lưu thông tin')
+    message.error("Đã xảy ra lỗi khi lưu thông tin");
   } finally {
-    visible.value = false
-    await fetchData({ ...param.value })
-    confirmLoading.value = false
+    visible.value = false;
+    await fetchData({ ...param.value });
+    confirmLoading.value = false;
   }
-}
+};
 
 const handleCancel = () => {
-  formRef.value?.resetFields()
-  visible.value = false
-}
+  formRef.value?.resetFields();
+  visible.value = false;
+};
 
-const deleteItem = async (id) => {
+const deleteItem = async id => {
   try {
-    await RestApi.timetable.delete({ params: { Id: id } })
-    message.success('Xóa thành công')
+    await RestApi.timetable.delete({ params: { Id: id } });
+    message.success("Xóa thành công");
   } catch (error) {
-    message.error('Đã xảy ra lỗi khi xóa')
+    message.error("Đã xảy ra lỗi khi xóa");
   } finally {
-    await fetchData({ ...param.value })
+    await fetchData({ ...param.value });
   }
-}
+};
 
-await fetchData({ ...param.value })
+await fetchData({ ...param.value });
+
+const drawerInfoOpen = ref(false);
+const infoRef = ref(null);
+
+watch(drawerInfoOpen, val => {
+  if (val) {
+    infoRef.value?.refresh?.();
+  }
+});
+
+const closeInfoDrawer = () => {
+  infoRef.value?.reset?.();
+};
+const openInfoDrawer = (reg) => {
+  
+  drawerInfoOpen.value = true
+}
 </script>
-
-<style scoped>
-@media (max-width: 768px) {
-  .ant-table-thead > tr > th,
-  .ant-table-tbody > tr > td {
-    padding: 8px !important;
-    font-size: 13px;
-  }
-
-  .ant-table-content {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-}
-
-.ant-table-cell-fix-left,
-.ant-table-cell-fix-right {
-  z-index: 1;
-  background: white;
-}
-
-.ant-table-cell-fix-right {
-  box-shadow: -5px 0 5px -5px rgba(0, 0, 0, 0.1);
-}
-</style>
 


### PR DESCRIPTION
## Summary
- integrate timetable API endpoints and service
- build timetable management page with search, CRUD and status display

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_6891d0e7fe3c83269c62f1a8f92d3518