### PR TITLE
feat: add rest editing and drag drop to timetable grid

### DIFF
--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -19,6 +19,7 @@
                 class="border p-2 text-xs align-top min-w-[120px] relative select-none"
                 :class="[
                   { 'cursor-move': ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock },
+                  { 'bg-green-50': ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock },
                   { 'bg-red-50': ngay.ds_Tiet[pIdx].isLock }
                 ]"
                 :draggable="ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock"

--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -165,6 +165,12 @@ function setRest(val) {
     cell.id_mon = 0
     cell.id_giao_vien = 0
   }
+  console.log(val ? 'Set rest period' : 'Cleared rest period', {
+    ca: contextMenu.ca,
+    ngay: contextMenu.ngay,
+    tiet: contextMenu.pIdx + 1,
+    data: { ...cell },
+  })
   contextMenu.show = false
 }
 
@@ -172,6 +178,12 @@ function setLock(val) {
   const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx)
   if (!cell) return
   cell.isLock = val
+  console.log(val ? 'Set locked period' : 'Cleared locked period', {
+    ca: contextMenu.ca,
+    ngay: contextMenu.ngay,
+    tiet: contextMenu.pIdx + 1,
+    data: { ...cell },
+  })
   contextMenu.show = false
 }
 

--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -103,7 +103,24 @@ function onDrop(caId, dayId, pIdx) {
   if (!dragSource.value) return
   const src = getCell(dragSource.value.caId, dragSource.value.dayId, dragSource.value.pIdx)
   const dst = getCell(caId, dayId, pIdx)
-  if (!src || !dst || src.isLock || dst.isLock) return
+  if (!src || !dst) return
+
+  console.log('Drag drop', {
+    source: {
+      ca: dragSource.value.caId,
+      ngay: dragSource.value.dayId,
+      tiet: dragSource.value.pIdx + 1,
+      data: { ...src },
+    },
+    destination: {
+      ca: caId,
+      ngay: dayId,
+      tiet: pIdx + 1,
+      data: { ...dst },
+    },
+  })
+
+  if (src.isLock || dst.isLock) return
 
   const keys = Object.keys(src).filter(k => !['id_ca', 'ngay', 'tiet'].includes(k))
   const temp = {}

--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div @click="contextMenu.show = false">
     <div v-for="ca in dsCa" :key="ca.id" class="mb-6">
       <h3 class="font-semibold mb-2">Ca {{ ca.id }}</h3>
       <div class="overflow-x-auto">
@@ -16,8 +16,14 @@
               <td
                 v-for="ngay in ca.ds_Ngay"
                 :key="ngay.id"
-                class="border p-2 text-xs align-top min-w-[120px]"
+                class="border p-2 text-xs align-top min-w-[120px] cursor-move relative"
+                :class="{ 'bg-red-50': ngay.ds_Tiet[pIdx].isLock }"
+                :draggable="!ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock"
+                @dragstart="onDragStart(ca.id, ngay.id, pIdx)"
+                @dragover.prevent
+                @drop="onDrop(ca.id, ngay.id, pIdx)"
                 @click="emit('cell-click', { ca: ca.id, ngay: ngay.id, tiet: pIdx + 1, record: ngay.ds_Tiet[pIdx] })"
+                @contextmenu.prevent="openContextMenu($event, ca.id, ngay.id, pIdx)"
               >
                 <template v-if="ngay.ds_Tiet[pIdx].isRest">
                   <span class="italic text-gray-500">Nghỉ</span>
@@ -29,11 +35,43 @@
                 <template v-else>
                   <span class="text-gray-400">Trống</span>
                 </template>
+                <div v-if="ngay.ds_Tiet[pIdx].isLock" class="absolute top-1 right-1 text-[10px] text-red-600">Khóa</div>
               </td>
             </tr>
           </tbody>
         </table>
       </div>
+    </div>
+
+    <!-- Context Menu -->
+    <div
+      v-if="contextMenu.show"
+      class="absolute bg-white border shadow rounded text-sm z-50"
+      :style="{ top: contextMenu.y + 'px', left: contextMenu.x + 'px' }"
+    >
+      <ul class="min-w-[150px] py-1">
+        <li
+          class="px-3 py-1 hover:bg-gray-100 cursor-pointer"
+          v-if="!contextMenu.cell?.isRest"
+          @click="setRest(true)"
+        >Đặt tiết nghỉ</li>
+        <li
+          class="px-3 py-1 hover:bg-gray-100 cursor-pointer"
+          v-else
+          @click="setRest(false)"
+        >Xóa tiết nghỉ</li>
+        <li
+          class="px-3 py-1 hover:bg-gray-100 cursor-pointer"
+          v-if="!contextMenu.cell?.isLock"
+          @click="setLock(true)"
+        >Đặt tiết khóa</li>
+        <li
+          class="px-3 py-1 hover:bg-gray-100 cursor-pointer"
+          v-else
+          @click="setLock(false)"
+        >Xóa tiết khóa</li>
+        <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click="clearCell">Xóa tiết</li>
+      </ul>
     </div>
   </div>
 </template>
@@ -41,10 +79,89 @@
 <script setup>
 const emit = defineEmits(['cell-click'])
 
-defineProps({
+const props = defineProps({
   dsCa: {
     type: Array,
     required: true,
   },
 });
+
+const dragSource = ref(null)
+const contextMenu = reactive({ show: false, x: 0, y: 0, ca: null, ngay: null, pIdx: null, cell: null })
+
+function getCell(caId, dayId, pIdx) {
+  const ca = props.dsCa.find(c => c.id === caId)
+  const ngay = ca?.ds_Ngay.find(n => n.id === dayId)
+  return ngay?.ds_Tiet[pIdx]
+}
+
+function onDragStart(caId, dayId, pIdx) {
+  dragSource.value = { caId, dayId, pIdx }
+}
+
+function onDrop(caId, dayId, pIdx) {
+  if (!dragSource.value) return
+  const src = getCell(dragSource.value.caId, dragSource.value.dayId, dragSource.value.pIdx)
+  const dst = getCell(caId, dayId, pIdx)
+  if (!src || !dst || src.isLock || dst.isLock) return
+
+  const keys = Object.keys(src).filter(k => !['id_ca', 'ngay', 'tiet'].includes(k))
+  const temp = {}
+  keys.forEach(k => (temp[k] = src[k]))
+  keys.forEach(k => (src[k] = dst[k]))
+  keys.forEach(k => (dst[k] = temp[k]))
+
+  dragSource.value = null
+}
+
+function openContextMenu(event, caId, dayId, pIdx) {
+  const cell = getCell(caId, dayId, pIdx)
+  contextMenu.show = true
+  contextMenu.x = event.clientX
+  contextMenu.y = event.clientY
+  contextMenu.ca = caId
+  contextMenu.ngay = dayId
+  contextMenu.pIdx = pIdx
+  contextMenu.cell = cell
+}
+
+function setRest(val) {
+  const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx)
+  if (!cell) return
+  cell.isRest = val
+  if (val) {
+    cell.ten_mon = ''
+    cell.ten_giao_vien = ''
+    cell.id_mon = 0
+    cell.id_giao_vien = 0
+  }
+  contextMenu.show = false
+}
+
+function setLock(val) {
+  const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx)
+  if (!cell) return
+  cell.isLock = val
+  contextMenu.show = false
+}
+
+function clearCell() {
+  const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx)
+  if (!cell) return
+  Object.assign(cell, {
+    id_chitiet: 0,
+    id_don_vi: 0,
+    id_tkb: 0,
+    id_mon: 0,
+    ten_mon: '',
+    id_giao_vien: 0,
+    ten_giao_vien: '',
+    id_phong: 0,
+    ten_phong: '',
+    tiet_thu_may: 0,
+    isRest: false,
+    isLock: false,
+  })
+  contextMenu.show = false
+}
 </script>

--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -16,9 +16,12 @@
               <td
                 v-for="ngay in ca.ds_Ngay"
                 :key="ngay.id"
-                class="border p-2 text-xs align-top min-w-[120px] cursor-move relative select-none"
-                :class="{ 'bg-red-50': ngay.ds_Tiet[pIdx].isLock }"
-                :draggable="!ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock"
+                class="border p-2 text-xs align-top min-w-[120px] relative select-none"
+                :class="[
+                  { 'cursor-move': ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock },
+                  { 'bg-red-50': ngay.ds_Tiet[pIdx].isLock }
+                ]"
+                :draggable="ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock"
                 @dragstart="onDragStart(ca.id, ngay.id, pIdx)"
                 @dragover="onDragOver($event, ca.id, ngay.id, pIdx)"
                 @drop="onDrop(ca.id, ngay.id, pIdx)"
@@ -96,6 +99,8 @@ function getCell(caId, dayId, pIdx) {
 }
 
 function onDragStart(caId, dayId, pIdx) {
+  const cell = getCell(caId, dayId, pIdx)
+  if (!cell?.isDrag) return
   dragSource.value = { caId, dayId, pIdx }
 }
 
@@ -120,7 +125,7 @@ function onDrop(caId, dayId, pIdx) {
     },
   })
 
-  if (src.isLock || src.isRest || dst.isLock || dst.isRest) return
+  if (src.isLock || src.isRest || dst.isLock || dst.isRest || !src.isDrag || !dst.isDrag) return
 
   const keys = Object.keys(src).filter(k => !['id_ca', 'ngay', 'tiet'].includes(k))
   const temp = {}
@@ -133,7 +138,7 @@ function onDrop(caId, dayId, pIdx) {
 
 function onDragOver(event, caId, dayId, pIdx) {
   const cell = getCell(caId, dayId, pIdx)
-  if (!cell?.isRest && !cell?.isLock) {
+  if (cell?.isDrag && !cell.isRest && !cell.isLock) {
     event.preventDefault()
   }
 }

--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -1,26 +1,26 @@
 <template>
   <div @click="contextMenu.show = false">
     <div v-for="ca in dsCa" :key="ca.id" class="mb-6">
-      <h3 class="font-semibold mb-2">Ca {{ ca.id }}</h3>
+      <h3 class="font-semibold mb-2 select-none">Ca {{ ca.id }}</h3>
       <div class="overflow-x-auto">
-        <table class="min-w-full border-collapse">
+        <table class="min-w-full border-collapse select-none">
           <thead>
             <tr>
-              <th class="border p-2">Tiết / Ngày</th>
-              <th v-for="ngay in ca.ds_Ngay" :key="ngay.id" class="border p-2">{{ ngay.ten }}</th>
+              <th class="border p-2 select-none">Tiết / Ngày</th>
+              <th v-for="ngay in ca.ds_Ngay" :key="ngay.id" class="border p-2 select-none">{{ ngay.ten }}</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="(tiet, pIdx) in ca.ds_Ngay[0].ds_Tiet" :key="pIdx">
-              <td class="border p-2 text-center font-medium">Tiết {{ pIdx + 1 }}</td>
+              <td class="border p-2 text-center font-medium select-none">Tiết {{ pIdx + 1 }}</td>
               <td
                 v-for="ngay in ca.ds_Ngay"
                 :key="ngay.id"
-                class="border p-2 text-xs align-top min-w-[120px] cursor-move relative"
+                class="border p-2 text-xs align-top min-w-[120px] cursor-move relative select-none"
                 :class="{ 'bg-red-50': ngay.ds_Tiet[pIdx].isLock }"
                 :draggable="!ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock"
                 @dragstart="onDragStart(ca.id, ngay.id, pIdx)"
-                @dragover.prevent
+                @dragover="onDragOver($event, ca.id, ngay.id, pIdx)"
                 @drop="onDrop(ca.id, ngay.id, pIdx)"
                 @click="emit('cell-click', { ca: ca.id, ngay: ngay.id, tiet: pIdx + 1, record: ngay.ds_Tiet[pIdx] })"
                 @contextmenu.prevent="openContextMenu($event, ca.id, ngay.id, pIdx)"
@@ -49,7 +49,7 @@
       class="absolute bg-white border shadow rounded text-sm z-50"
       :style="{ top: contextMenu.y + 'px', left: contextMenu.x + 'px' }"
     >
-      <ul class="min-w-[150px] py-1">
+      <ul class="min-w-[150px] py-1 select-none">
         <li
           class="px-3 py-1 hover:bg-gray-100 cursor-pointer"
           v-if="!contextMenu.cell?.isRest"
@@ -120,7 +120,7 @@ function onDrop(caId, dayId, pIdx) {
     },
   })
 
-  if (src.isLock || dst.isLock) return
+  if (src.isLock || src.isRest || dst.isLock || dst.isRest) return
 
   const keys = Object.keys(src).filter(k => !['id_ca', 'ngay', 'tiet'].includes(k))
   const temp = {}
@@ -129,6 +129,13 @@ function onDrop(caId, dayId, pIdx) {
   keys.forEach(k => (dst[k] = temp[k]))
 
   dragSource.value = null
+}
+
+function onDragOver(event, caId, dayId, pIdx) {
+  const cell = getCell(caId, dayId, pIdx)
+  if (!cell?.isRest && !cell?.isLock) {
+    event.preventDefault()
+  }
 }
 
 function openContextMenu(event, caId, dayId, pIdx) {

--- a/public/data.json
+++ b/public/data.json
@@ -17,9 +17,9 @@
         "id_ca": 1,
         "ngay": 1,
         "tiet": 1,
-        "isDrag": false,
+        "isDrag": true,
         "isLock": false,
-        "isRest": true
+        "isRest": false
       },
       {
         "id_chitiet": 1,
@@ -28,14 +28,14 @@
         "id_mon": 2,
         "ten_mon": "Tiếng Anh",
         "id_giao_vien": 8,
-        "ten_giao_vien": "",
+        "ten_giao_vien": "tên giáo viên",
         "id_phong": 2,
         "ten_phong": "Không cần phòng",
         "tiet_thu_may": 1,
         "id_ca": 1,
         "ngay": 1,
         "tiet": 2,
-        "isDrag": false,
+        "isDrag": true,
         "isLock": false,
         "isRest": false
       },


### PR DESCRIPTION
## Summary
- support locked slots and drag/drop swapping in TimetableGrid
- add context menu to mark rest, lock, or clear a period

## Testing
- `yarn test` *(fails: Command "test" not found)*


------
https://chatgpt.com/codex/tasks/task_e_689d4bad78f4832c9d0ced25b91ec6ff