### PR TITLE
Include unassigned records when flattening timetable

### DIFF
--- a/composables/useTimetable.js
+++ b/composables/useTimetable.js
@@ -164,11 +164,14 @@ export function toFlatRecordsFromGrid(grid, options = {}) {
  *
  * @param {Array} ds_Ca - cấu trúc lưới từ transformTimetable
  * @param {Array} [unassigned=[]] - các bản ghi chưa gán (nếu có)
- * @param {Object} [options] - tham số giống toFlatRecordsFromGrid
+ * @param {Object} [options] - tham số giống toFlatRecordsFromGrid (includeBlanks mặc định true)
  * @returns {Array<Object>} danh sách bản ghi flat
  */
 export function gridToFlat(ds_Ca, unassigned = [], options = {}) {
-  return toFlatRecordsFromGrid({ ds_Ca, unassigned }, options);
+  return toFlatRecordsFromGrid(
+    { ds_Ca, unassigned },
+    { includeBlanks: true, ...options }
+  );
 }
 
 /**

--- a/composables/useTimetable.js
+++ b/composables/useTimetable.js
@@ -81,6 +81,10 @@ export function transformTimetable(records = [], opts = {}) {
     ds_Ca.push({ id: caId, ds_Ngay });
   }
 
+  if (unassigned.length) {
+    console.log("Unassigned periods:", unassigned);
+  }
+
   return { ds_Ca, unassigned, index };
 }
 

--- a/composables/useTimetable.js
+++ b/composables/useTimetable.js
@@ -91,14 +91,14 @@ export function transformTimetable(records = [], opts = {}) {
  * @param {Object} [options]
  * @param {boolean} [options.includeRests=true]  - có đưa tiết nghỉ (isRest) vào danh sách không
  * @param {boolean} [options.includeBlanks=false]- có đưa ô trống vào danh sách không
- * @param {Array<Object>} [options.mergeUnassigned] - mảng unassigned để cộng dồn
+ * @param {Array<Object>} [options.mergeUnassigned] - mảng unassigned để cộng dồn (mặc định dùng grid.unassigned)
  * @param {Object} [options.baseDefaults] - default cho ô trống/thiếu data
  * @returns {Array<Object>}
  */
 export function toFlatRecordsFromGrid(grid, options = {}) {
   const includeRests = options.includeRests ?? true;
   const includeBlanks = options.includeBlanks ?? false;
-  const mergeUnassigned = options.mergeUnassigned ?? [];
+  const mergeUnassigned = options.mergeUnassigned ?? grid?.unassigned ?? [];
   const baseDefaults = {
     id_don_vi: 1,
     id_tkb: 2,
@@ -146,8 +146,9 @@ export function toFlatRecordsFromGrid(grid, options = {}) {
     }
   }
 
-  // cộng thêm các ô unassigned nếu muốn
+  // cộng thêm các ô unassigned nếu có
   if (Array.isArray(mergeUnassigned) && mergeUnassigned.length) {
+    console.log("Unassigned periods:", mergeUnassigned);
     out.push(...mergeUnassigned);
   }
 

--- a/pages/timetable.vue
+++ b/pages/timetable.vue
@@ -9,7 +9,7 @@
       <div class="max-h-64 overflow-auto p-3 text-xs grid gap-4 md:grid-cols-3">
         <div>
           <h4 class="font-semibold mb-1">Dữ liệu đầu vào</h4>
-          <pre>{{ JSON.stringify(rawInput, null, 2) }}</pre>
+          <pre>{{ rawInput.length }} /{{ JSON.stringify(rawInput, null, 2) }}</pre>
         </div>
         <div>
           <h4 class="font-semibold mb-1">Sau chuyển đổi</h4>
@@ -17,7 +17,7 @@
         </div>
         <div>
           <h4 class="font-semibold mb-1">Chuyển ngược</h4>
-          <pre>{{ JSON.stringify(reverted, null, 2) }}</pre>
+          <pre>{{ reverted.length }} /{{ JSON.stringify(reverted, null, 2) }}</pre>
         </div>
       </div>
     </details>


### PR DESCRIPTION
## Summary
- ensure `toFlatRecordsFromGrid` includes `grid.unassigned` by default when flattening timetable data
- document unassigned merge behavior
- log unassigned periods when flattening

## Testing
- `npm test` *(fails: Missing script: "test"))*

------
https://chatgpt.com/codex/tasks/task_e_689d5ce1c72c832cb3847cd4a592fed8