### PR TITLE
Refactor timetable grid to consume raw data

### DIFF
--- a/components/Select/Class.vue
+++ b/components/Select/Class.vue
@@ -1,0 +1,86 @@
+<template>
+  <a-form-item :label="label" :name="name" :rules="rules">
+    <a-select
+      :value="modelValue"
+      @update:value="val => $emit('update:modelValue', val)"
+      :mode="multiple ? 'multiple' : undefined"
+      show-search
+      :placeholder="placeholder"
+      :loading="loading"
+      :disabled="disabled"
+      allow-clear
+      class="w-full"
+      :options="options"
+      @search="onSearch"
+      :filter-option="false"
+    />
+  </a-form-item>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import debounce from 'lodash/debounce'
+
+const { RestApi } = useApi()
+
+const props = defineProps({
+  modelValue: [Array, Number, String],
+  label: { type: String, default: 'Lớp học' },
+  name: { type: String, default: 'lophoc' },
+  multiple: { type: Boolean, default: false },
+  placeholder: { type: String, default: 'Chọn lớp học' },
+  rules: { type: Array, default: () => [] },
+  disabled: { type: Boolean, default: false },
+  /** ID khối lớp để lọc danh sách lớp */
+  id_khoi: { type: [Number, String], default: null },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const options = ref([])
+const loading = ref(false)
+
+const fetchClasses = async (search = '') => {
+  loading.value = true
+  try {
+    const params = {
+      PageIndex: 1,
+      PageSize: 10,
+    }
+    if (search) params.search = search
+    if (props.id_khoi) params.id_khoilop = props.id_khoi
+    const { data } = await RestApi.class.list({ params })
+    if (data.value?.data?.items) {
+      options.value = data.value.data.items.map(item => ({
+        label: item.ten,
+        value: item.id,
+      }))
+      if (
+        props.modelValue === undefined ||
+        props.modelValue === null ||
+        props.modelValue === ''
+      ) {
+        emit('update:modelValue', props.modelValue)
+      }
+    }
+  } catch (error) {
+    console.error('❌ Lỗi fetch lớp học:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+const debouncedFetch = debounce(val => {
+  fetchClasses(val.trim())
+}, 300)
+
+const onSearch = val => {
+  debouncedFetch(val)
+}
+
+watch(() => props.id_khoi, () => {
+  fetchClasses()
+})
+
+await fetchClasses()
+</script>

--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -13,7 +13,22 @@
           <tbody>
             <tr v-for="(tiet, pIdx) in ca.ds_Ngay[0].ds_Tiet" :key="pIdx">
               <td class="border p-2 text-center font-medium select-none">Tiết {{ pIdx + 1 }}</td>
-              <td v-for="ngay in ca.ds_Ngay" :key="ngay.id" class="border p-2 text-xs align-top min-w-[120px] relative select-none" :class="[{ 'cursor-move': ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock }, { 'bg-green-50': ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock }, { 'bg-red-50': ngay.ds_Tiet[pIdx].isLock }]" :draggable="ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock" @dragstart="onDragStart(ca.id, ngay.id, pIdx)" @dragover="onDragOver($event, ca.id, ngay.id, pIdx)" @drop="onDrop(ca.id, ngay.id, pIdx)" @click="emit('cell-click', { ca: ca.id, ngay: ngay.id, tiet: pIdx + 1, record: ngay.ds_Tiet[pIdx] })" @contextmenu.prevent="openContextMenu($event, ca.id, ngay.id, pIdx)">
+              <td
+                v-for="ngay in ca.ds_Ngay"
+                :key="ngay.id"
+                class="border p-2 text-xs align-top min-w-[120px] relative select-none"
+                :class="[
+                  { 'cursor-move': ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock },
+                  { 'bg-green-50': ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock },
+                  { 'bg-red-50': ngay.ds_Tiet[pIdx].isLock },
+                ]"
+                :draggable="ngay.ds_Tiet[pIdx].isDrag && !ngay.ds_Tiet[pIdx].isRest && !ngay.ds_Tiet[pIdx].isLock"
+                @dragstart="onDragStart(ca.id, ngay.id, pIdx)"
+                @dragover="onDragOver($event, ca.id, ngay.id, pIdx)"
+                @drop="onDrop(ca.id, ngay.id, pIdx)"
+                @click="emit('cell-click', { ca: ca.id, ngay: ngay.id, tiet: pIdx + 1, record: ngay.ds_Tiet[pIdx] })"
+                @contextmenu.prevent="openContextMenu($event, ca.id, ngay.id, pIdx)"
+              >
                 <template v-if="ngay.ds_Tiet[pIdx].isRest">
                   <span class="italic text-red-500">Nghỉ</span>
                 </template>
@@ -33,7 +48,11 @@
     </div>
 
     <!-- Context Menu -->
-    <div v-if="contextMenu.show" class="absolute bg-white border shadow rounded text-sm z-50" :style="{ top: contextMenu.y + 'px', left: contextMenu.x + 'px' }">
+    <div
+      v-if="contextMenu.show"
+      class="absolute bg-white border shadow rounded text-sm z-50"
+      :style="{ top: contextMenu.y + 'px', left: contextMenu.x + 'px' }"
+    >
       <ul class="min-w-[150px] py-1 select-none">
         <li
           class="px-3 py-1 hover:bg-gray-100 cursor-pointer"
@@ -73,24 +92,81 @@
         <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click="clearCell">Xóa tiết</li>
       </ul>
     </div>
+
+    <a-modal
+      v-model:open="showAddModal"
+      title="Chọn tiết học"
+      ok-text="Thêm"
+      cancel-text="Hủy"
+      @ok="confirmAdd"
+      @cancel="showAddModal = false"
+    >
+      <a-select v-model:value="selectedIdx" class="w-full mb-4">
+        <a-select-option
+          v-for="(lesson, idx) in rawUnscheduled"
+          :key="idx"
+          :value="idx"
+        >
+          {{ lesson.ten_mon }} - {{ lesson.ten_giao_vien }}
+        </a-select-option>
+      </a-select>
+    </a-modal>
   </div>
 </template>
 
 <script setup>
-const emit = defineEmits(["cell-click", "cell-clear", "cell-add"]);
+import { transformTimetable, gridToFlat } from "@/composables/useTimetable";
 
 const props = defineProps({
-  dsCa: {
+  rawTimetable: {
+    type: Array,
+    required: true,
+  },
+  rawUnscheduled: {
     type: Array,
     required: true,
   },
 });
 
+const dsCa = ref([]);
+const emit = defineEmits(["cell-click"]);
+const showAddModal = ref(false);
+const selectedIdx = ref(0);
+const targetCell = ref(null);
+
+watch(
+  () => props.rawTimetable,
+  () => {
+    const { ds_Ca } = transformTimetable(props.rawTimetable, {
+      daysCount: 7,
+      shifts: [1, 2],
+      periodsPerShift: 5,
+      dayNames: [
+        "Thứ 2",
+        "Thứ 3",
+        "Thứ 4",
+        "Thứ 5",
+        "Thứ 6",
+        "Thứ 7",
+        "Chủ Nhật",
+      ],
+    });
+    dsCa.value = ds_Ca;
+  },
+  { immediate: true, deep: true }
+);
+
+function updateRawTimetable() {
+  const flat = gridToFlat(dsCa.value, props.rawUnscheduled);
+  props.rawTimetable.length = 0;
+  props.rawTimetable.push(...flat);
+}
+
 const dragSource = ref(null);
 const contextMenu = reactive({ show: false, x: 0, y: 0, ca: null, ngay: null, pIdx: null, cell: null });
 
 function getCell(caId, dayId, pIdx) {
-  const ca = props.dsCa.find(c => c.id === caId);
+  const ca = dsCa.value.find(c => c.id === caId);
   const ngay = ca?.ds_Ngay.find(n => n.id === dayId);
   return ngay?.ds_Tiet[pIdx];
 }
@@ -129,8 +205,8 @@ function onDrop(caId, dayId, pIdx) {
   keys.forEach(k => (temp[k] = src[k]));
   keys.forEach(k => (src[k] = dst[k]));
   keys.forEach(k => (dst[k] = temp[k]));
-
   dragSource.value = null;
+  updateRawTimetable();
 }
 
 function onDragOver(event, caId, dayId, pIdx) {
@@ -168,6 +244,7 @@ function setRest(val) {
     data: { ...cell },
   });
   contextMenu.show = false;
+  updateRawTimetable();
 }
 
 function setLock(val) {
@@ -181,6 +258,7 @@ function setLock(val) {
     data: { ...cell },
   });
   contextMenu.show = false;
+  updateRawTimetable();
 }
 
 function clearCell() {
@@ -210,7 +288,7 @@ function clearCell() {
     isRest: false,
     isLock: false,
   });
-  if (hasData) emit("cell-clear", removed);
+  if (hasData) props.rawUnscheduled.push({ ...removed });
   console.log("Cleared Cell", {
     ca: contextMenu.ca,
     ngay: contextMenu.ngay,
@@ -218,18 +296,33 @@ function clearCell() {
     data: { ...cell },
   });
   contextMenu.show = false;
+  updateRawTimetable();
 }
 
-  function addLesson() {
-    const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
-    if (!cell || cell.ten_mon) return;
-    emit("cell-add", { record: cell });
-    console.log("Add lesson request", {
-      ca: contextMenu.ca,
-      ngay: contextMenu.ngay,
-      tiet: contextMenu.pIdx + 1,
-      data: { ...cell },
-    });
-    contextMenu.show = false;
-  }
+function addLesson() {
+  const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
+  if (!cell || cell.ten_mon) return;
+  targetCell.value = cell;
+  selectedIdx.value = 0;
+  showAddModal.value = true;
+  contextMenu.show = false;
+}
+
+function confirmAdd() {
+  if (selectedIdx.value == null || !targetCell.value) return;
+  const lesson = props.rawUnscheduled.splice(selectedIdx.value, 1)[0];
+  if (!lesson) return;
+  const cell = targetCell.value;
+  cell.id_mon = lesson.id_mon;
+  cell.ten_mon = lesson.ten_mon;
+  cell.id_giao_vien = lesson.id_giao_vien;
+  cell.ten_giao_vien = lesson.ten_giao_vien;
+  cell.id_phong = lesson.id_phong;
+  cell.ten_phong = lesson.ten_phong;
+  cell.tiet_thu_may = lesson.tiet_thu_may;
+  showAddModal.value = false;
+  targetCell.value = null;
+  console.log("Lesson added", { cell: { ...cell }, lesson });
+  updateRawTimetable();
+}
 </script>

--- a/pages/list_management/timetable.vue
+++ b/pages/list_management/timetable.vue
@@ -71,7 +71,7 @@
     <a-drawer v-model:open="drawerAdjustOpen" title="Tinh chỉnh thời khóa biểu" :footer="null" height="100vh" placement="bottom">
       <ClientOnly>
         <div class="mb-4">
-          <SelectGradeLevel v-model="adjustGradeId" />
+          <SelectClass v-model="adjustClassId" />
         </div>
         <TimetableGrid :rawTimetable="adjustRawTimetable" :rawUnscheduled="adjustRawUnscheduled" />
       </ClientOnly>
@@ -245,7 +245,7 @@ const infoRef = ref(null);
 const drawerAdjustOpen = ref(false);
 const adjustRawTimetable = ref([]);
 const adjustRawUnscheduled = ref([]);
-const adjustGradeId = ref(null);
+const adjustClassId = ref(null);
 const adjustTimetableId = ref(null);
 
 watch(drawerInfoOpen, val => {
@@ -262,10 +262,10 @@ const openInfoDrawer = (reg) => {
   drawerInfoOpen.value = true
 }
 const fetchAdjustData = async () => {
-  if (!adjustGradeId.value || !adjustTimetableId.value) return;
+  if (!adjustClassId.value || !adjustTimetableId.value) return;
   try {
     const { data } = await RestApi.request.get('/api/tkb/lop', {
-      params: { idLop: adjustGradeId.value, idtkb: adjustTimetableId.value },
+      params: { idLop: adjustClassId.value, idtkb: adjustTimetableId.value },
     });
     if (data.value?.status === 'success') {
       const raw = data.value.data;
@@ -290,7 +290,7 @@ const fetchAdjustData = async () => {
   }
 };
 
-watch([adjustGradeId, adjustTimetableId], fetchAdjustData);
+watch([adjustClassId, adjustTimetableId], fetchAdjustData);
 
 const openAdjustDrawer = record => {
   adjustTimetableId.value = record.id;

--- a/pages/list_management/timetable.vue
+++ b/pages/list_management/timetable.vue
@@ -70,6 +70,9 @@
     </a-drawer>
     <a-drawer v-model:open="drawerAdjustOpen" title="Tinh chỉnh thời khóa biểu" :footer="null" height="100vh" placement="bottom">
       <ClientOnly>
+        <div class="mb-4">
+          <SelectGradeLevel v-model="adjustGradeId" />
+        </div>
         <TimetableGrid :rawTimetable="adjustRawTimetable" :rawUnscheduled="adjustRawUnscheduled" />
       </ClientOnly>
     </a-drawer>
@@ -242,6 +245,8 @@ const infoRef = ref(null);
 const drawerAdjustOpen = ref(false);
 const adjustRawTimetable = ref([]);
 const adjustRawUnscheduled = ref([]);
+const adjustGradeId = ref(null);
+const adjustTimetableId = ref(null);
 
 watch(drawerInfoOpen, val => {
   if (val) {
@@ -256,21 +261,41 @@ const openInfoDrawer = (reg) => {
 
   drawerInfoOpen.value = true
 }
-const openAdjustDrawer = async record => {
-  const raw = await $fetch("/data.json");
-  adjustRawTimetable.value = raw.data.timetable;
-  adjustRawUnscheduled.value = raw.data.ds_chua_xep.map(
-    ({ id_mon, ten_mon, id_giao_vien, ten_giao_vien, id_phong, ten_phong, tiet_thu_may }) => ({
-      id_mon,
-      ten_mon,
-      id_giao_vien,
-      ten_giao_vien,
-      id_phong,
-      ten_phong,
-      tiet_thu_may,
-    })
-  );
+const fetchAdjustData = async () => {
+  if (!adjustGradeId.value || !adjustTimetableId.value) return;
+  try {
+    const { data } = await RestApi.request.get('/api/tkb/lop', {
+      params: { idLop: adjustGradeId.value, idtkb: adjustTimetableId.value },
+    });
+    if (data.value?.status === 'success') {
+      const raw = data.value.data;
+      adjustRawTimetable.value = raw.timetable;
+      adjustRawUnscheduled.value = raw.ds_chua_xep.map(
+        ({ id_mon, ten_mon, id_giao_vien, ten_giao_vien, id_phong, ten_phong, tiet_thu_may }) => ({
+          id_mon,
+          ten_mon,
+          id_giao_vien,
+          ten_giao_vien,
+          id_phong,
+          ten_phong,
+          tiet_thu_may,
+        }),
+      );
+    } else {
+      adjustRawTimetable.value = [];
+      adjustRawUnscheduled.value = [];
+    }
+  } catch (error) {
+    message.error('Lỗi khi tải thời khóa biểu');
+  }
+};
+
+watch([adjustGradeId, adjustTimetableId], fetchAdjustData);
+
+const openAdjustDrawer = record => {
+  adjustTimetableId.value = record.id;
   drawerAdjustOpen.value = true;
+  fetchAdjustData();
 };
 </script>
 

--- a/pages/list_management/timetable.vue
+++ b/pages/list_management/timetable.vue
@@ -23,6 +23,11 @@
                   <template #icon><CalendarOutlined /></template>
                 </a-button>
               </a-tooltip>
+              <a-tooltip title="Tinh chỉnh">
+                <a-button type="link" size="small" @click="openAdjustDrawer(record)">
+                  <template #icon><SettingOutlined /></template>
+                </a-button>
+              </a-tooltip>
               <a-tooltip title="Sửa">
                 <a-button type="link" size="small" @click="editItem(record)">
                   <template #icon><EditOutlined /></template>
@@ -61,6 +66,11 @@
     <a-drawer v-model:open="drawerInfoOpen" title="Xếp thời khóa biểu" :footer="null" height="100vh" placement="bottom" @close="closeInfoDrawer">
       <ClientOnly>
         <TimetableInfo ref="infoRef" />
+      </ClientOnly>
+    </a-drawer>
+    <a-drawer v-model:open="drawerAdjustOpen" title="Tinh chỉnh thời khóa biểu" :footer="null" height="100vh" placement="bottom">
+      <ClientOnly>
+        <TimetableGrid :rawTimetable="adjustRawTimetable" :rawUnscheduled="adjustRawUnscheduled" />
       </ClientOnly>
     </a-drawer>
   </div>
@@ -229,6 +239,9 @@ await fetchData({ ...param.value });
 
 const drawerInfoOpen = ref(false);
 const infoRef = ref(null);
+const drawerAdjustOpen = ref(false);
+const adjustRawTimetable = ref([]);
+const adjustRawUnscheduled = ref([]);
 
 watch(drawerInfoOpen, val => {
   if (val) {
@@ -240,8 +253,24 @@ const closeInfoDrawer = () => {
   infoRef.value?.reset?.();
 };
 const openInfoDrawer = (reg) => {
-  
+
   drawerInfoOpen.value = true
 }
+const openAdjustDrawer = async record => {
+  const raw = await $fetch("/data.json");
+  adjustRawTimetable.value = raw.data.timetable;
+  adjustRawUnscheduled.value = raw.data.ds_chua_xep.map(
+    ({ id_mon, ten_mon, id_giao_vien, ten_giao_vien, id_phong, ten_phong, tiet_thu_may }) => ({
+      id_mon,
+      ten_mon,
+      id_giao_vien,
+      ten_giao_vien,
+      id_phong,
+      ten_phong,
+      tiet_thu_may,
+    })
+  );
+  drawerAdjustOpen.value = true;
+};
 </script>
 

--- a/pages/timetable.vue
+++ b/pages/timetable.vue
@@ -6,18 +6,10 @@
     <h2 class="text-xl font-semibold mb-2">Thời khóa biểu 11A1</h2>
     <details class="border rounded">
       <summary class="cursor-pointer px-3 py-2 bg-gray-200 hover:bg-gray-300 rounded-t">Xem dữ liệu JSON</summary>
-      <div class="max-h-64 overflow-auto p-3 text-xs grid gap-4 md:grid-cols-4">
+      <div class="max-h-64 overflow-auto p-3 text-xs grid gap-4 md:grid-cols-2">
         <div>
-          <h4 class="font-semibold mb-1">Dữ liệu đầu vào</h4>
+          <h4 class="font-semibold mb-1">Thời khóa biểu</h4>
           <pre>{{ rawTimetable.length }} /{{ JSON.stringify(rawTimetable, null, 2) }}</pre>
-        </div>
-        <div>
-          <h4 class="font-semibold mb-1">Sau chuyển đổi</h4>
-          <pre>{{ JSON.stringify(dsCa, null, 2) }}</pre>
-        </div>
-        <div>
-          <h4 class="font-semibold mb-1">Chuyển ngược</h4>
-          <pre>{{ reverted.length }} /{{ JSON.stringify(reverted, null, 2) }}</pre>
         </div>
         <div>
           <h4 class="font-semibold mb-1">Tiết chưa xếp</h4>
@@ -25,34 +17,12 @@
         </div>
       </div>
     </details>
-    <TimetableGrid :dsCa="dsCa" @cell-clear="onCellClear" @cell-add="onCellAdd" />
-
-    <a-modal
-      v-model:open="showAddModal"
-      title="Chọn tiết học"
-      ok-text="Thêm"
-      cancel-text="Hủy"
-      @ok="confirmAdd"
-      @cancel="showAddModal = false"
-    >
-      <a-select v-model:value="selectedIdx" class="w-full mb-4">
-        <a-select-option v-for="(lesson, idx) in rawUnscheduled" :key="idx" :value="idx">
-          {{ lesson.ten_mon }} - {{ lesson.ten_giao_vien }}
-        </a-select-option>
-      </a-select>
-    </a-modal>
+    <TimetableGrid :rawTimetable="rawTimetable" :rawUnscheduled="rawUnscheduled" />
   </div>
 </template>
 <script setup>
-import { transformTimetable, gridToFlat } from "@/composables/useTimetable";
-
 const rawTimetable = ref([]);
 const rawUnscheduled = ref([]);
-const dsCa = ref([]);
-const reverted = computed(() => gridToFlat(dsCa.value, rawUnscheduled.value));
-const showAddModal = ref(false);
-const selectedIdx = ref(0);
-const targetCell = ref(null);
 
 onMounted(async () => {
   const raw = await $fetch("/data.json");
@@ -76,41 +46,5 @@ onMounted(async () => {
       tiet_thu_may,
     })
   );
-  const { ds_Ca } = transformTimetable(rawTimetable.value, {
-    daysCount: 7,
-    shifts: [1, 2],
-    periodsPerShift: 5,
-    dayNames: ["Thứ 2", "Thứ 3", "Thứ 4", "Thứ 5", "Thứ 6", "Thứ 7", "Chủ Nhật"],
-  });
-  dsCa.value = ds_Ca;
 });
-
-function onCellAdd({ record }) {
-  if (rawUnscheduled.value.length === 0) return;
-  targetCell.value = record;
-  selectedIdx.value = 0;
-  showAddModal.value = true;
-}
-
-  function confirmAdd() {
-    if (selectedIdx.value == null || !targetCell.value) return;
-    const lesson = rawUnscheduled.value.splice(selectedIdx.value, 1)[0];
-    if (!lesson) return;
-    const cell = targetCell.value;
-    cell.id_mon = lesson.id_mon;
-    cell.ten_mon = lesson.ten_mon;
-    cell.id_giao_vien = lesson.id_giao_vien;
-    cell.ten_giao_vien = lesson.ten_giao_vien;
-    cell.id_phong = lesson.id_phong;
-    cell.ten_phong = lesson.ten_phong;
-    cell.tiet_thu_may = lesson.tiet_thu_may;
-    showAddModal.value = false;
-    targetCell.value = null;
-    console.log("Lesson added", { cell: { ...cell }, lesson });
-  }
-
-function onCellClear(record) {
-  rawUnscheduled.value.push({ ...record });
-  console.log("Unscheduled added", record);
-}
 </script>


### PR DESCRIPTION
## Summary
- Move scheduling logic into `TimetableGrid` so component transforms `rawTimetable` and manages `rawUnscheduled`
- Update timetable page to pass raw data directly to the component

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_689da10bb994832ca7a73450b9d72434