### PR TITLE
Refresh timetable after drag drop update

### DIFF
--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -167,6 +167,19 @@ async function onDrop(caId, dayId, pIdx) {
     const { data, error } = await RestApi.timetable.update_class({ body });
     if (data.value?.status !== "success") {
       console.error("Update timetable error", error.value || data.value);
+    } else {
+      try {
+        const { data: listData, error: listError } = await RestApi.timetable.list({
+          params: { id_lop: props.classId },
+        });
+        if (listData.value?.status === "success") {
+          emit("update:rawTimetable", listData.value.data);
+        } else {
+          console.error("Load timetable error", listError.value || listData.value);
+        }
+      } catch (listErr) {
+        console.error("Load timetable error", listErr);
+      }
     }
   } catch (err) {
     console.error("Update timetable error", err);

--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -166,23 +166,24 @@ async function onDrop(caId, dayId, pIdx) {
     };
     const { data, error } = await RestApi.timetable.update_class({ body });
     if (data.value?.status !== "success") {
-      console.error("Update timetable error", error.value || data.value);
+      message.error("Update timetable error", error.value || data.value);
     } else {
       try {
-        const { data: listData, error: listError } = await RestApi.timetable.list({
-          params: { id_lop: props.classId },
+        const { data: listData, error: listError } = await RestApi.request.get("/api/tkb/lop", {
+          params: { idLop: props.classId, idtkb: dstClone.id_tkb },
         });
         if (listData.value?.status === "success") {
-          emit("update:rawTimetable", listData.value.data);
+          emit("update:rawTimetable", listData.value.data.timetable);
+          emit("update:rawUnscheduled", listData.value.data.ds_chua_xep);
         } else {
-          console.error("Load timetable error", listError.value || listData.value);
+          message.error("Load timetable error", listError.value || listData.value);
         }
       } catch (listErr) {
-        console.error("Load timetable error", listErr);
+        message.error("Load timetable error", listErr);
       }
     }
   } catch (err) {
-    console.error("Update timetable error", err);
+    message.error("Update timetable error", err);
   }
 }
 


### PR DESCRIPTION
## Summary
- reload timetable using RestApi.timetable.list after successful drag drop update

## Testing
- `yarn build` *(fails: Nitro build step did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_689ea4da3ee0832cbb72d4b639b1a9a7