### PR TITLE
refactor: use useApi for timetable class retrieval

### DIFF
--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -169,7 +169,7 @@ async function onDrop(caId, dayId, pIdx) {
       message.error("Update timetable error", error.value || data.value);
     } else {
       try {
-        const { data: listData, error: listError } = await RestApi.request.get("/api/tkb/lop", {
+        const { data: listData, error: listError } = await RestApi.timetable.get_class({
           params: { idLop: props.classId, idtkb: dstClone.id_tkb },
         });
         if (listData.value?.status === "success") {

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -75,6 +75,7 @@ let ENDPOINTS = {
   TIMETABLE: "/api/thoikhoabieu",
   TIMETABLE_FIND_CLASS_POSITION: "/api/tkb/timvitri/lop",
   TIMETABLE_UPDATE_CLASS: "/api/tkb/update/lop",
+  TIMETABLE_CLASS: "/api/tkb/lop",
 
   S3: "/api/presigned_url",
 };
@@ -721,6 +722,9 @@ class Timetable {
   }
   async update_class(data) {
     return await this.request.post(ENDPOINTS.TIMETABLE_UPDATE_CLASS, data);
+  }
+  async get_class(data) {
+    return await this.request.get(ENDPOINTS.TIMETABLE_CLASS, data);
   }
 }
 export default () => {

--- a/pages/list_management/timetable.vue
+++ b/pages/list_management/timetable.vue
@@ -268,7 +268,7 @@ const openInfoDrawer = (reg) => {
 const fetchAdjustData = async () => {
   if (!adjustClassId.value || !adjustTimetableId.value) return;
   try {
-    const { data } = await RestApi.request.get('/api/tkb/lop', {
+    const { data } = await RestApi.timetable.get_class({
       params: { idLop: adjustClassId.value, idtkb: adjustTimetableId.value },
     });
     if (data.value?.status === 'success') {


### PR DESCRIPTION
## Summary
- register timetable class route in useApi
- use RestApi.timetable.get_class instead of hardcoded endpoint

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_689ea9e89484832c9d973f3e08134cba