### PR TITLE
feat: add tabs to timetable grid

### DIFF
--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -1,54 +1,55 @@
 <template>
   <div @click="contextMenu.show = false">
-    <div v-for="ca in dsCa" :key="ca.id" class="mb-6">
-      <h3 class="font-semibold mb-2 select-none">Ca {{ ca.id }}</h3>
-      <div class="overflow-x-auto">
-        <table class="min-w-full border-collapse select-none">
-          <thead>
-            <tr>
-              <th class="border p-2 select-none">Tiết / Ngày</th>
-              <th v-for="ngay in ca.ds_Ngay" :key="ngay.id" class="border p-2 select-none">{{ ngay.ten }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(tiet, pIdx) in ca.ds_Ngay[0].ds_Tiet" :key="pIdx">
-              <td class="border p-2 text-center font-medium select-none">Tiết {{ pIdx + 1 }}</td>
-              <td
-                v-for="ngay in ca.ds_Ngay"
-                :key="ngay.id"
-                class="border p-2 text-xs align-top min-w-[120px] relative select-none"
-                :class="cellClasses(ca.id, ngay.id, pIdx, ngay.ds_Tiet[pIdx])"
-                :draggable="isDraggable(ngay.ds_Tiet[pIdx])"
-                @dragstart="onDragStart(ca.id, ngay.id, pIdx)"
-                @dragover="onDragOver($event, ca.id, ngay.id, pIdx)"
-                @drop="onDrop(ca.id, ngay.id, pIdx)"
-                @click="onCellClick(ca.id, ngay.id, pIdx)"
-                @contextmenu.prevent="openContextMenu($event, ca.id, ngay.id, pIdx)"
-              >
-                <template v-if="ngay.ds_Tiet[pIdx].isRest">
-                  <span class="italic text-red-500">Nghỉ</span>
-                </template>
-                <template v-else-if="ngay.ds_Tiet[pIdx].ten_mon">
-                  <div class="font-medium leading-tight">
-                    {{ ngay.ds_Tiet[pIdx].ten_mon }} - {{ ngay.ds_Tiet[pIdx].ten_giao_vien }}
-                  </div>
-                  <div class="text-gray-600">{{ ngay.ds_Tiet[pIdx].ten_phong }}</div>
-                </template>
-                <template v-else>
-                  <span class="text-gray-400">Trống</span>
-                </template>
-                <div
-                  v-if="ngay.ds_Tiet[pIdx].isLock"
-                  class="absolute top-1 right-1 text-[10px] text-red-600"
+    <a-tabs v-model:activeKey="activeCa">
+      <a-tab-pane v-for="ca in dsCa" :key="ca.id" :tab="`Ca ${ca.id}`">
+        <div class="overflow-x-auto">
+          <table class="min-w-full border-collapse select-none">
+            <thead>
+              <tr>
+                <th class="border p-2 select-none">Tiết / Ngày</th>
+                <th v-for="ngay in ca.ds_Ngay" :key="ngay.id" class="border p-2 select-none">{{ ngay.ten }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(tiet, pIdx) in ca.ds_Ngay[0].ds_Tiet" :key="pIdx">
+                <td class="border p-2 text-center font-medium select-none">Tiết {{ pIdx + 1 }}</td>
+                <td
+                  v-for="ngay in ca.ds_Ngay"
+                  :key="ngay.id"
+                  class="border p-2 text-xs align-top min-w-[120px] relative select-none"
+                  :class="cellClasses(ca.id, ngay.id, pIdx, ngay.ds_Tiet[pIdx])"
+                  :draggable="isDraggable(ngay.ds_Tiet[pIdx])"
+                  @dragstart="onDragStart(ca.id, ngay.id, pIdx)"
+                  @dragover="onDragOver($event, ca.id, ngay.id, pIdx)"
+                  @drop="onDrop(ca.id, ngay.id, pIdx)"
+                  @click="onCellClick(ca.id, ngay.id, pIdx)"
+                  @contextmenu.prevent="openContextMenu($event, ca.id, ngay.id, pIdx)"
                 >
-                  Khóa
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
+                  <template v-if="ngay.ds_Tiet[pIdx].isRest">
+                    <span class="italic text-red-500">Nghỉ</span>
+                  </template>
+                  <template v-else-if="ngay.ds_Tiet[pIdx].ten_mon">
+                    <div class="font-medium leading-tight">
+                      {{ ngay.ds_Tiet[pIdx].ten_mon }} - {{ ngay.ds_Tiet[pIdx].ten_giao_vien }}
+                    </div>
+                    <div class="text-gray-600">{{ ngay.ds_Tiet[pIdx].ten_phong }}</div>
+                  </template>
+                  <template v-else>
+                    <span class="text-gray-400">Trống</span>
+                  </template>
+                  <div
+                    v-if="ngay.ds_Tiet[pIdx].isLock"
+                    class="absolute top-1 right-1 text-[10px] text-red-600"
+                  >
+                    Khóa
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </a-tab-pane>
+    </a-tabs>
 
     <!-- Context Menu -->
     <div v-if="contextMenu.show" class="absolute bg-white border shadow rounded text-sm z-50" :style="{ top: contextMenu.y + 'px', left: contextMenu.x + 'px' }">
@@ -90,6 +91,7 @@ const props = defineProps({
 });
 
 const dsCa = ref([]);
+const activeCa = ref(1);
 const emit = defineEmits(["cell-click", "update:rawTimetable", "update:rawUnscheduled"]);
 const showAddModal = ref(false);
 const selectedIdx = ref(0);
@@ -107,6 +109,7 @@ watch(
       dayNames: ["Thứ 2", "Thứ 3", "Thứ 4", "Thứ 5", "Thứ 6", "Thứ 7", "Chủ Nhật"],
     });
     dsCa.value = ds_Ca;
+    activeCa.value = ds_Ca[0]?.id || 1;
   },
   { immediate: true, deep: true },
 );


### PR DESCRIPTION
## Summary
- swap timetable layout to Ant Design Vue tabs for shifts
- track active shift with state and initialize after transform

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_689ebdf5ed84832c827e2868e35f993c