### PR TITLE
feat: add subject arrangement modal

### DIFF
--- a/components/TimetableInfo.vue
+++ b/components/TimetableInfo.vue
@@ -229,22 +229,8 @@ defineExpose({ refresh, reset });
         </div>
       </div>
     </div>
-    <a-modal
-      v-model:open="subjectModal.visible"
-      title="Xếp Môn học"
-      :confirm-loading="subjectModal.loading"
-      @ok="confirmArrangeSubject"
-      @cancel="subjectModal.visible = false"
-      width="800px"
-    >
-      <a-table
-        :columns="subjectColumns"
-        :data-source="subjectModal.data"
-        :row-selection="subjectRowSelection"
-        row-key="id"
-        :pagination="false"
-        :scroll="{ y: 400 }"
-      />
+    <a-modal v-model:open="subjectModal.visible" title="Xếp Môn học" :confirm-loading="subjectModal.loading" @ok="confirmArrangeSubject" @cancel="subjectModal.visible = false" width="800px">
+      <a-table :columns="subjectColumns" :data-source="subjectModal.data" :row-selection="subjectRowSelection" row-key="id" :pagination="false" :scroll="{ y: 600 }" size="small" />
     </a-modal>
   </div>
 </template>

--- a/components/TimetableInfo.vue
+++ b/components/TimetableInfo.vue
@@ -243,6 +243,7 @@ defineExpose({ refresh, reset });
         :row-selection="subjectRowSelection"
         row-key="id"
         :pagination="false"
+        :scroll="{ y: 400 }"
       />
     </a-modal>
   </div>

--- a/components/TimetableInfo.vue
+++ b/components/TimetableInfo.vue
@@ -20,6 +20,62 @@ const arrangedLessons = computed(() => info.tong_tiet_da_xep);
 const unarrangedLessons = computed(() => info.tong_tiet_chua_xep);
 
 const settingStore = useSettingStore();
+const subjectModal = reactive({
+  visible: false,
+  loading: false,
+  data: [],
+  selectedRowKeys: [],
+});
+const subjectColumns = [
+  { title: "Tên môn học", dataIndex: "ten" },
+  { title: "Tổng tiết", dataIndex: "tong_tiet" },
+  { title: "Tiết chưa xếp", dataIndex: "tiet_chua_xep" },
+  { title: "Tiết đã xếp", dataIndex: "tiet_da_xep" },
+];
+const subjectRowSelection = computed(() => ({
+  selectedRowKeys: subjectModal.selectedRowKeys,
+  onChange: keys => (subjectModal.selectedRowKeys = keys),
+}));
+
+const fetchSubjectLessons = async () => {
+  subjectModal.loading = true;
+  try {
+    const { data } = await RestApi.timetable.subject_list({
+      params: { idtkb: props.timetableId },
+    });
+    subjectModal.data = data.value?.data || [];
+  } catch (err) {
+    console.error("Fetch subject lessons error", err);
+  } finally {
+    subjectModal.loading = false;
+  }
+};
+const openSubjectModal = async () => {
+  await fetchSubjectLessons();
+  subjectModal.visible = true;
+};
+const confirmArrangeSubject = async () => {
+  if (!subjectModal.selectedRowKeys.length) {
+    subjectModal.visible = false;
+    return;
+  }
+  subjectModal.loading = true;
+  try {
+    const { data } = await RestApi.timetable.arrange_subject({
+      body: { id_tkb: props.timetableId, ids: subjectModal.selectedRowKeys },
+    });
+    if (data.value?.status === "success") {
+      message.success(data.value.message || data.value.data || "");
+    }
+    subjectModal.visible = false;
+    subjectModal.selectedRowKeys = [];
+    await fetchInfo();
+  } catch (err) {
+    console.error("Arrange subjects error", err);
+  } finally {
+    subjectModal.loading = false;
+  }
+};
 const arrangeAll = async () => {
   settingStore.setLoading(true);
   try {
@@ -48,7 +104,7 @@ const arrangePartial = type => {
       console.log("Thực hiện xếp Giáo viên chủ nhiệm");
       break;
     case "Xếp Môn học":
-      console.log("Thực hiện xếp Môn học");
+      openSubjectModal();
       break;
     case "Xếp Giáo viên":
       console.log("Thực hiện xếp Giáo viên");
@@ -173,6 +229,22 @@ defineExpose({ refresh, reset });
         </div>
       </div>
     </div>
+    <a-modal
+      v-model:open="subjectModal.visible"
+      title="Xếp Môn học"
+      :confirm-loading="subjectModal.loading"
+      @ok="confirmArrangeSubject"
+      @cancel="subjectModal.visible = false"
+      width="800px"
+    >
+      <a-table
+        :columns="subjectColumns"
+        :data-source="subjectModal.data"
+        :row-selection="subjectRowSelection"
+        row-key="id"
+        :pagination="false"
+      />
+    </a-modal>
   </div>
 </template>
 

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -88,6 +88,8 @@ let ENDPOINTS = {
   TIMETABLE_CANCEL_PERIOD: "/api/tkb/huytiet",
   TIMETABLE_CANCEL_RESULT: "/api/thoikhoabieu/huykq",
   TIMETABLE_ARRANGE_ALL: "/api/tkb",
+  TIMETABLE_SUBJECT_LIST: "/api/sotiet/monhoc",
+  TIMETABLE_ARRANGE_SUBJECT: "/api/tkb/xeptheomon",
 
   S3: "/api/presigned_url",
 };
@@ -773,6 +775,12 @@ class Timetable {
   }
   async arrange_all(data) {
     return await this.request.post(ENDPOINTS.TIMETABLE_ARRANGE_ALL, data);
+  }
+  async subject_list(data) {
+    return await this.request.get(ENDPOINTS.TIMETABLE_SUBJECT_LIST, data);
+  }
+  async arrange_subject(data) {
+    return await this.request.post(ENDPOINTS.TIMETABLE_ARRANGE_SUBJECT, data);
   }
 }
 export default () => {


### PR DESCRIPTION
## Summary
- add API helpers for subject-based arranging
- allow choosing multiple subjects to arrange in TimetableInfo modal

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68a421e48630832c850ae02531cec4ee