### PR TITLE
Add separate lock APIs for class and teacher timetables

### DIFF
--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -572,8 +572,32 @@ async function setLock(val) {
   const cell = contextMenu.isTeacher ? getTeacherCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx) : getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
   if (!cell || !cell.id_chitiet) return;
   try {
-    if (val) {
-      const { data, error } = await RestApi.timetable.lock_period({ params: { Id: cell.id_chitiet } });
+    if (contextMenu.isTeacher) {
+      const api = val
+        ? RestApi.timetable.lock_teacher_period
+        : RestApi.timetable.unlock_teacher_period;
+      const { data, error } = await api({ params: { Id: cell.id_chitiet } });
+      if (data.value?.status === "success") {
+        if (selectedClassId.value && props.timetableId) {
+          const { data: listData, error: listError } = await RestApi.timetable.get_class({
+            params: { idLop: selectedClassId.value, idtkb: cell.id_tkb },
+          });
+          if (listData.value?.status === "success") {
+            emit("update:rawTimetable", listData.value.data.timetable);
+            emit("update:rawUnscheduled", listData.value.data.ds_chua_xep);
+          } else {
+            message.error("Load timetable error", listError.value || listData.value);
+          }
+        }
+        await fetchTeacherTimetable(selectedTeacherId.value);
+      } else {
+        message.error("Set lock error", error.value || data.value);
+      }
+    } else {
+      const api = val
+        ? RestApi.timetable.lock_class_period
+        : RestApi.timetable.unlock_class_period;
+      const { data, error } = await api({ params: { Id: cell.id_chitiet } });
       if (data.value?.status === "success") {
         const { data: listData, error: listError } = await RestApi.timetable.get_class({
           params: { idLop: selectedClassId.value, idtkb: cell.id_tkb },
@@ -589,22 +613,8 @@ async function setLock(val) {
         if (selectedTeacherId.value && props.timetableId) {
           await fetchTeacherTimetable(selectedTeacherId.value);
         }
-      }
-    } else {
-      const { data, error } = await RestApi.timetable.unlock_period({ params: { Id: cell.id_chitiet } });
-      if (data.value?.status === "success") {
-        const { data: listData, error: listError } = await RestApi.timetable.get_class({
-          params: { idLop: selectedClassId.value, idtkb: cell.id_tkb },
-        });
-        if (listData.value?.status === "success") {
-          emit("update:rawTimetable", listData.value.data.timetable);
-          emit("update:rawUnscheduled", listData.value.data.ds_chua_xep);
-        } else {
-          message.error("Load timetable error", listError.value || listData.value);
-        }
-        if (selectedTeacherId.value && props.timetableId) {
-          await fetchTeacherTimetable(selectedTeacherId.value);
-        }
+      } else {
+        message.error("Set lock error", error.value || data.value);
       }
     }
   } catch (err) {

--- a/composables/useApi.js
+++ b/composables/useApi.js
@@ -85,6 +85,10 @@ let ENDPOINTS = {
   TIMETABLE_TEACHER: "/api/tkb/giaovien",
   TIMETABLE_LOCK_PERIOD: "/api/tkb/khoatiet",
   TIMETABLE_UNLOCK_PERIOD: "/api/tkb/huykhoa",
+  TIMETABLE_LOCK_CLASS_PERIOD: "/api/tkb/khoatiet/mon",
+  TIMETABLE_UNLOCK_CLASS_PERIOD: "/api/tkb/huykhoa/mon",
+  TIMETABLE_LOCK_TEACHER_PERIOD: "/api/tkb/khoatiet/giaovien",
+  TIMETABLE_UNLOCK_TEACHER_PERIOD: "/api/tkb/huykhoa/giaovien",
   TIMETABLE_CANCEL_PERIOD: "/api/tkb/huytiet",
   TIMETABLE_CANCEL_RESULT: "/api/thoikhoabieu/huykq",
   TIMETABLE_ARRANGE_ALL: "/api/tkb",
@@ -777,6 +781,18 @@ class Timetable {
   }
   async unlock_period(data) {
     return await this.request.put(ENDPOINTS.TIMETABLE_UNLOCK_PERIOD, data);
+  }
+  async lock_class_period(data) {
+    return await this.request.put(ENDPOINTS.TIMETABLE_LOCK_CLASS_PERIOD, data);
+  }
+  async unlock_class_period(data) {
+    return await this.request.put(ENDPOINTS.TIMETABLE_UNLOCK_CLASS_PERIOD, data);
+  }
+  async lock_teacher_period(data) {
+    return await this.request.put(ENDPOINTS.TIMETABLE_LOCK_TEACHER_PERIOD, data);
+  }
+  async unlock_teacher_period(data) {
+    return await this.request.put(ENDPOINTS.TIMETABLE_UNLOCK_TEACHER_PERIOD, data);
   }
   async cancel_period(data) {
     return await this.request.put(ENDPOINTS.TIMETABLE_CANCEL_PERIOD, data);


### PR DESCRIPTION
## Summary
- support new lock/unlock endpoints for class and teacher timetables
- update TimetableGrid setLock to use new APIs

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68a699d4ebe0832c8421e9025a13be38