### PR TITLE
feat: add bulk lock options for timetable

### DIFF
--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -98,6 +98,14 @@
         <template v-else>
           <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click="addLesson">Xếp tiết</li>
         </template>
+        <template v-if="!contextMenu.isTeacher && contextMenu.cell?.id_mon">
+          <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click="lockSubjectPeriods">Khóa tất cả tiết môn</li>
+          <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click="unlockSubjectPeriods">Huỷ khóa tất cả tiết môn</li>
+        </template>
+        <template v-if="contextMenu.isTeacher && selectedTeacherId">
+          <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click="lockTeacherPeriods">Khóa tất cả tiết giáo viên</li>
+          <li class="px-3 py-1 hover:bg-gray-100 cursor-pointer" @click="unlockTeacherPeriods">Huỷ khóa tất cả tiết giáo viên</li>
+        </template>
       </ul>
     </div>
 
@@ -610,6 +618,114 @@ async function setLock(val) {
   } catch (err) {
     message.error("Set lock error", err);
   }
+}
+
+async function lockSubjectPeriods() {
+  const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
+  if (!cell?.id_mon) return;
+  try {
+    const { data, error } = await RestApi.timetable.lock_class_period({ params: { Id: cell.id_mon } });
+    if (data.value?.status === "success") {
+      const { data: listData, error: listError } = await RestApi.timetable.get_class({
+        params: { idLop: selectedClassId.value, idtkb: cell.id_tkb },
+      });
+      if (listData.value?.status === "success") {
+        emit("update:rawTimetable", listData.value.data.timetable);
+        emit("update:rawUnscheduled", listData.value.data.ds_chua_xep);
+      } else {
+        message.error("Load timetable error", listError.value || listData.value);
+      }
+      if (selectedTeacherId.value && props.timetableId) {
+        await fetchTeacherTimetable(selectedTeacherId.value);
+      }
+    } else {
+      message.error("Lock subject periods error", error.value || data.value);
+    }
+  } catch (err) {
+    message.error("Lock subject periods error", err);
+  }
+  contextMenu.show = false;
+}
+
+async function unlockSubjectPeriods() {
+  const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
+  if (!cell?.id_mon) return;
+  try {
+    const { data, error } = await RestApi.timetable.unlock_class_period({ params: { Id: cell.id_mon } });
+    if (data.value?.status === "success") {
+      const { data: listData, error: listError } = await RestApi.timetable.get_class({
+        params: { idLop: selectedClassId.value, idtkb: cell.id_tkb },
+      });
+      if (listData.value?.status === "success") {
+        emit("update:rawTimetable", listData.value.data.timetable);
+        emit("update:rawUnscheduled", listData.value.data.ds_chua_xep);
+      } else {
+        message.error("Load timetable error", listError.value || listData.value);
+      }
+      if (selectedTeacherId.value && props.timetableId) {
+        await fetchTeacherTimetable(selectedTeacherId.value);
+      }
+    } else {
+      message.error("Unlock subject periods error", error.value || data.value);
+    }
+  } catch (err) {
+    message.error("Unlock subject periods error", err);
+  }
+  contextMenu.show = false;
+}
+
+async function lockTeacherPeriods() {
+  const teacherId = selectedTeacherId.value;
+  if (!teacherId) return;
+  try {
+    const { data, error } = await RestApi.timetable.lock_teacher_period({ params: { Id: teacherId } });
+    if (data.value?.status === "success") {
+      if (selectedClassId.value && props.timetableId) {
+        const { data: listData, error: listError } = await RestApi.timetable.get_class({
+          params: { idLop: selectedClassId.value, idtkb: props.timetableId },
+        });
+        if (listData.value?.status === "success") {
+          emit("update:rawTimetable", listData.value.data.timetable);
+          emit("update:rawUnscheduled", listData.value.data.ds_chua_xep);
+        } else {
+          message.error("Load timetable error", listError.value || listData.value);
+        }
+      }
+      await fetchTeacherTimetable(teacherId);
+    } else {
+      message.error("Lock teacher periods error", error.value || data.value);
+    }
+  } catch (err) {
+    message.error("Lock teacher periods error", err);
+  }
+  contextMenu.show = false;
+}
+
+async function unlockTeacherPeriods() {
+  const teacherId = selectedTeacherId.value;
+  if (!teacherId) return;
+  try {
+    const { data, error } = await RestApi.timetable.unlock_teacher_period({ params: { Id: teacherId } });
+    if (data.value?.status === "success") {
+      if (selectedClassId.value && props.timetableId) {
+        const { data: listData, error: listError } = await RestApi.timetable.get_class({
+          params: { idLop: selectedClassId.value, idtkb: props.timetableId },
+        });
+        if (listData.value?.status === "success") {
+          emit("update:rawTimetable", listData.value.data.timetable);
+          emit("update:rawUnscheduled", listData.value.data.ds_chua_xep);
+        } else {
+          message.error("Load timetable error", listError.value || listData.value);
+        }
+      }
+      await fetchTeacherTimetable(teacherId);
+    } else {
+      message.error("Unlock teacher periods error", error.value || data.value);
+    }
+  } catch (err) {
+    message.error("Unlock teacher periods error", err);
+  }
+  contextMenu.show = false;
 }
 
 async function clearCell() {

--- a/components/TimetableGrid.vue
+++ b/components/TimetableGrid.vue
@@ -622,9 +622,9 @@ async function setLock(val) {
 
 async function lockSubjectPeriods() {
   const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
-  if (!cell?.id_mon) return;
+  if (!cell?.id_chitiet) return;
   try {
-    const { data, error } = await RestApi.timetable.lock_class_period({ params: { Id: cell.id_mon } });
+    const { data, error } = await RestApi.timetable.lock_class_period({ params: { Id: cell.id_chitiet } });
     if (data.value?.status === "success") {
       const { data: listData, error: listError } = await RestApi.timetable.get_class({
         params: { idLop: selectedClassId.value, idtkb: cell.id_tkb },
@@ -649,9 +649,9 @@ async function lockSubjectPeriods() {
 
 async function unlockSubjectPeriods() {
   const cell = getCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
-  if (!cell?.id_mon) return;
+  if (!cell?.id_chitiet) return;
   try {
-    const { data, error } = await RestApi.timetable.unlock_class_period({ params: { Id: cell.id_mon } });
+    const { data, error } = await RestApi.timetable.unlock_class_period({ params: { Id: cell.id_chitiet } });
     if (data.value?.status === "success") {
       const { data: listData, error: listError } = await RestApi.timetable.get_class({
         params: { idLop: selectedClassId.value, idtkb: cell.id_tkb },
@@ -675,10 +675,10 @@ async function unlockSubjectPeriods() {
 }
 
 async function lockTeacherPeriods() {
-  const teacherId = selectedTeacherId.value;
-  if (!teacherId) return;
+  const cell = getTeacherCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
+  if (!cell?.id_chitiet) return;
   try {
-    const { data, error } = await RestApi.timetable.lock_teacher_period({ params: { Id: teacherId } });
+    const { data, error } = await RestApi.timetable.lock_teacher_period({ params: { Id: cell.id_chitiet } });
     if (data.value?.status === "success") {
       if (selectedClassId.value && props.timetableId) {
         const { data: listData, error: listError } = await RestApi.timetable.get_class({
@@ -691,7 +691,9 @@ async function lockTeacherPeriods() {
           message.error("Load timetable error", listError.value || listData.value);
         }
       }
-      await fetchTeacherTimetable(teacherId);
+      if (selectedTeacherId.value && props.timetableId) {
+        await fetchTeacherTimetable(selectedTeacherId.value);
+      }
     } else {
       message.error("Lock teacher periods error", error.value || data.value);
     }
@@ -702,10 +704,10 @@ async function lockTeacherPeriods() {
 }
 
 async function unlockTeacherPeriods() {
-  const teacherId = selectedTeacherId.value;
-  if (!teacherId) return;
+  const cell = getTeacherCell(contextMenu.ca, contextMenu.ngay, contextMenu.pIdx);
+  if (!cell?.id_chitiet) return;
   try {
-    const { data, error } = await RestApi.timetable.unlock_teacher_period({ params: { Id: teacherId } });
+    const { data, error } = await RestApi.timetable.unlock_teacher_period({ params: { Id: cell.id_chitiet } });
     if (data.value?.status === "success") {
       if (selectedClassId.value && props.timetableId) {
         const { data: listData, error: listError } = await RestApi.timetable.get_class({
@@ -718,7 +720,9 @@ async function unlockTeacherPeriods() {
           message.error("Load timetable error", listError.value || listData.value);
         }
       }
-      await fetchTeacherTimetable(teacherId);
+      if (selectedTeacherId.value && props.timetableId) {
+        await fetchTeacherTimetable(selectedTeacherId.value);
+      };
     } else {
       message.error("Unlock teacher periods error", error.value || data.value);
     }


### PR DESCRIPTION
## Summary
- add context menu actions to lock/unlock all subject periods in class timetable
- add context menu actions to lock/unlock all teacher periods in teacher timetable
- separate bulk lock and unlock handlers for clarity

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6da23f060832cac6c553320e6b086